### PR TITLE
Add fragment caching to responsive layouts.

### DIFF
--- a/app/views/layouts/partials/inline_js/_base_js_async.html.haml
+++ b/app/views/layouts/partials/inline_js/_base_js_async.html.haml
@@ -1,24 +1,25 @@
-:javascript
-  if (!window.lp.enhanced) {
-    (function() {
+- cache [__FILE__, local_assigns.map(&:to_s)] do
+  :javascript
+    if (!window.lp.enhanced) {
+      (function() {
 
-      var firstScript = document.getElementsByTagName("script")[0],
-          js = document.createElement("script");
+        var firstScript = document.getElementsByTagName("script")[0],
+            js = document.createElement("script");
 
-      js.src = "#{normalised_asset_path('omniture/s_code.js')}";
+        js.src = "#{normalised_asset_path('omniture/s_code.js')}";
 
-      js.onload = function(){
-        var property;
-        if (window.s && window.lp.tracking) {
-          for (property in window.lp.tracking) {
-            window.s[property] = window.lp.tracking[property];
+        js.onload = function(){
+          var property;
+          if (window.s && window.lp.tracking) {
+            for (property in window.lp.tracking) {
+              window.s[property] = window.lp.tracking[property];
+            }
+            if (typeof window.s.t === 'function') {
+              window.s.t();
+            }
           }
-          if (typeof window.s.t === 'function') {
-            window.s.t();
-          }
-        }
-      };
+        };
 
-      firstScript.parentNode.insertBefore(js, firstScript);
-    }());
-  }
+        firstScript.parentNode.insertBefore(js, firstScript);
+      }());
+    }

--- a/app/views/layouts/partials/inline_js/_cut_the_mustard.html.haml
+++ b/app/views/layouts/partials/inline_js/_cut_the_mustard.html.haml
@@ -1,9 +1,9 @@
-:javascript
-  if('querySelector' in document && 
-     'localStorage' in window && 
-     'addEventListener' in window &&
-     'classList' in document.documentElement) {
-    (function(H){H.className=H.className.replace(/\bbase\b/,'enhanced')})(document.documentElement);
-    window.lp.enhanced = true;
-  }
-  
+- cache [__FILE__] do
+  :javascript
+    if('querySelector' in document && 
+       'localStorage' in window && 
+       'addEventListener' in window &&
+       'classList' in document.documentElement) {
+      (function(H){H.className=H.className.replace(/\bbase\b/,'enhanced')})(document.documentElement);
+      window.lp.enhanced = true;
+    }

--- a/app/views/layouts/partials/inline_js/_fonts_async.html.haml
+++ b/app/views/layouts/partials/inline_js/_fonts_async.html.haml
@@ -1,21 +1,22 @@
-:javascript
-  (function(){
-    if (window.lp.enhanced && 
-        window.lp.supports.localStorage && 
-        window.localStorage.getItem('_lpfont') != "true") {
+- cache [__FILE__, local_assigns.map(&:to_s)] do
+  :javascript
+    (function(){
+      if (window.lp.enhanced && 
+          window.lp.supports.localStorage && 
+          window.localStorage.getItem('_lpfont') != "true") {
 
-      window.onload = function() {
-        var xhr = new XMLHttpRequest(),
-            fontPath = "#{font_path('fonts.css')}";
+        window.onload = function() {
+          var xhr = new XMLHttpRequest(),
+              fontPath = "#{font_path('fonts.css')}";
 
-        xhr.open('GET', fontPath);
+          xhr.open('GET', fontPath);
 
-        xhr.onload = function (e) {
-          window.localStorage.setItem('_lpfont', 'true')
-        };
+          xhr.onload = function (e) {
+            window.localStorage.setItem('_lpfont', 'true')
+          };
 
-        xhr.send();
+          xhr.send();
+        }
+
       }
-
-    }
-  })()
+    })()

--- a/app/views/layouts/partials/inline_js/_fonts_loader.html.haml
+++ b/app/views/layouts/partials/inline_js/_fonts_loader.html.haml
@@ -1,15 +1,16 @@
-:javascript
-  if (window.lp.enhanced && window.localStorage.getItem('_lpfont') == "true") {
-    var ss = document.createElement('link'),
-        firstLink = document.getElementsByTagName('link')[0],
-        fontPath = "#{font_path('fonts.css')}";
+- cache [__FILE__] do
+  :javascript
+    if (window.lp.enhanced && window.localStorage.getItem('_lpfont') == "true") {
+      var ss = document.createElement('link'),
+          firstLink = document.getElementsByTagName('link')[0],
+          fontPath = "#{font_path('fonts.css')}";
 
-    
-    ss.href= fontPath;
-    ss.rel = "stylesheet";
-    ss.type = "text/css";
-    firstLink.parentNode.insertBefore(ss, firstLink);
 
-    // Replace the no-freight classname
-    (function(H){H.className=H.className.replace(/\bno-freight\b/,'freight')})(document.documentElement);
-  }
+      ss.href= fontPath;
+      ss.rel = "stylesheet";
+      ss.type = "text/css";
+      firstLink.parentNode.insertBefore(ss, firstLink);
+
+      // Replace the no-freight classname
+      (function(H){H.className=H.className.replace(/\bno-freight\b/,'freight')})(document.documentElement);
+    }

--- a/app/views/layouts/partials/inline_js/_fs_init.html.haml
+++ b/app/views/layouts/partials/inline_js/_fs_init.html.haml
@@ -1,12 +1,13 @@
-:javascript
-  window.lp.fs.log(function(){
-    return {
-      url: window.location.href,
-      referrer: document.referrer,
-      username: window.lp.getCookie("lpCookie") && window.lp.getCookie("lpCookie").split('#')[0],
-      country: window.lp.getCookie("country"),
-      viewport: document.documentElement.clientWidth,
-      variant: window.lp.getCookie("_v"),
-      schema: "0.1"
-    };
-  }());
+- cache [__FILE__, local_assigns.map(&:to_s)] do
+  :javascript
+    window.lp.fs.log(function(){
+      return {
+        url: window.location.href,
+        referrer: document.referrer,
+        username: window.lp.getCookie("lpCookie") && window.lp.getCookie("lpCookie").split('#')[0],
+        country: window.lp.getCookie("country"),
+        viewport: document.documentElement.clientWidth,
+        variant: window.lp.getCookie("_v"),
+        schema: "0.1"
+      };
+    }());

--- a/app/views/layouts/partials/inline_js/_grunticon.html.haml
+++ b/app/views/layouts/partials/inline_js/_grunticon.html.haml
@@ -1,40 +1,41 @@
-:javascript
-  (function() {
-    var docElement = document.documentElement,
-        activePath = "#{normalised_asset_path('icons/active.css')}",
-        criticalPath = "#{normalised_asset_path('icons/critical.css')}";
-    
-    function styleSheet(path) {
-      var link = document.createElement("link");
-      link.rel = "stylesheet";
-      link.type = "text/css";
-      link.href = path;
-      return link;
-    }
-    
-    function supportsSVG() {
-      var hasBgSize = ("background-size" in docElement.style || "backgroundSize" in docElement.style),
-          hasSvg = !!window.document.createElementNS && 
-                   !!window.document.createElementNS('http://www.w3.org/2000/svg', 'svg').createSVGRect && 
-                   !!document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#Image", "1.1") && 
-                   !(window.opera && navigator.userAgent.indexOf('Chrome') === -1),
-          enhanced = window.lp.enhanced;
-      
-      return hasBgSize && hasSvg && enhanced;
-    }
+- cache [__FILE__, local_assigns.map(&:to_s)] do
+  :javascript
+    (function() {
+      var docElement = document.documentElement,
+          activePath = "#{normalised_asset_path('icons/active.css')}",
+          criticalPath = "#{normalised_asset_path('icons/critical.css')}";
 
-    window.setTimeout(function(){
-      var script = document.getElementsByTagName("script")[0];
-      var head = script.parentNode;
-      if (supportsSVG()) {
-        head.insertBefore(styleSheet(activePath), script);
-        docElement.className += " supports-svg";
-      } else {
-        head.insertBefore(styleSheet(criticalPath), script);
-        docElement.className += " no-background-size";
+      function styleSheet(path) {
+        var link = document.createElement("link");
+        link.rel = "stylesheet";
+        link.type = "text/css";
+        link.href = path;
+        return link;
       }
-    }, 0)
-  }());
 
-%noscript
-  %link{href: "#{normalised_asset_path('icons/critical.css')}", rel: "stylesheet"}
+      function supportsSVG() {
+        var hasBgSize = ("background-size" in docElement.style || "backgroundSize" in docElement.style),
+            hasSvg = !!window.document.createElementNS && 
+                     !!window.document.createElementNS('http://www.w3.org/2000/svg', 'svg').createSVGRect && 
+                     !!document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#Image", "1.1") && 
+                     !(window.opera && navigator.userAgent.indexOf('Chrome') === -1),
+            enhanced = window.lp.enhanced;
+
+        return hasBgSize && hasSvg && enhanced;
+      }
+
+      window.setTimeout(function(){
+        var script = document.getElementsByTagName("script")[0];
+        var head = script.parentNode;
+        if (supportsSVG()) {
+          head.insertBefore(styleSheet(activePath), script);
+          docElement.className += " supports-svg";
+        } else {
+          head.insertBefore(styleSheet(criticalPath), script);
+          docElement.className += " no-background-size";
+        }
+      }, 0)
+    }());
+
+  %noscript
+    %link{href: "#{normalised_asset_path('icons/critical.css')}", rel: "stylesheet"}

--- a/app/views/layouts/partials/inline_js/_require_js_async.html.haml
+++ b/app/views/layouts/partials/inline_js/_require_js_async.html.haml
@@ -1,13 +1,14 @@
-:javascript
-  (function(d, s) {
-    var ie = document.documentElement.className.match(/ie([0-9]+)/);
-    if (window.lp.enhanced || ie) {
-      var firstJs, js;
-      firstJs = d.getElementsByTagName(s)[0];
-      js = d.createElement(s);
-      js.async = true;
-      js.src = "#{normalised_asset_path('requirejs/require.js')}";
-      js.setAttribute("data-main", "#{async_js_path(script_name)}");
-      firstJs.parentNode.insertBefore(js, firstJs);
-    }
-  })(document, 'script');
+- cache [__FILE__, local_assigns.map(&:to_s), Rizzo::COMMIT] do
+  :javascript
+    (function(d, s) {
+      var ie = document.documentElement.className.match(/ie([0-9]+)/);
+      if (window.lp.enhanced || ie) {
+        var firstJs, js;
+        firstJs = d.getElementsByTagName(s)[0];
+        js = d.createElement(s);
+        js.async = true;
+        js.src = "#{normalised_asset_path('requirejs/require.js')}";
+        js.setAttribute("data-main", "#{async_js_path(script_name)}");
+        firstJs.parentNode.insertBefore(js, firstJs);
+      }
+    })(document, 'script');

--- a/app/views/layouts/partials/inline_js/_require_js_config.html.haml
+++ b/app/views/layouts/partials/inline_js/_require_js_config.html.haml
@@ -1,20 +1,21 @@
-:javascript
-  var require = require || {
-    baseUrl: '/assets',
-    paths: {
-      flamsteed: "flamsteed/lib/javascripts/flamsteed",
-      hogan: "hogan/dist/hogan-3.0.0.amd",
-      jplugs: "jquery-plugins",
-      jquery:  "jquery/jquery",
-      jtimeago: "jquery-timeago/jquery.timeago",
-      sailthru: "sailthru/v1",
-      sCode: "omniture/s_code",
-      trackjs: "trackjs/trackjs",
-      dfp: "jquery.dfp.js/jquery.dfp",
-      autocomplete: "autocomplete/dist/autocomplete",
-      d3: "d3/d3",
-      nvd3: "nvd3/nv.d3",
-      picturefill: "picturefill/dist/picturefill"
-    },
-    waitSeconds: 30
-  };
+- cache [__FILE__] do
+  :javascript
+    var require = {
+      baseUrl: '/assets',
+      paths: {
+        flamsteed: "flamsteed/lib/javascripts/flamsteed",
+        hogan: "hogan/dist/hogan-3.0.0.amd",
+        jplugs: "jquery-plugins",
+        jquery:  "jquery/jquery",
+        jtimeago: "jquery-timeago/jquery.timeago",
+        sailthru: "sailthru/v1",
+        sCode: "omniture/s_code",
+        trackjs: "trackjs/trackjs",
+        dfp: "jquery.dfp.js/jquery.dfp",
+        autocomplete: "autocomplete/dist/autocomplete",
+        d3: "d3/d3",
+        nvd3: "nvd3/nv.d3",
+        picturefill: "picturefill/dist/picturefill"
+      },
+      waitSeconds: 30
+    };

--- a/app/views/layouts/partials/inline_js/_tynt.html.haml
+++ b/app/views/layouts/partials/inline_js/_tynt.html.haml
@@ -1,6 +1,7 @@
-:javascript
-  if (!/https/.test(location.protocol)) {
-    <!-- BEGIN Tynt Script -->
-    var Tynt=Tynt||[];Tynt.push('dSm5i4oRer4BQKacwqm_6l');
-    (function(){var s=document.createElement('script');s.async="async";s.type="text/javascript";s.src='http://tcr.tynt.com/ti.js';var h=document.getElementsByTagName('script')[0];h.parentNode.insertBefore(s,h);})();
-  }
+- cache [__FILE__, local_assigns.map(&:to_s)] do
+  :javascript
+    if (!/https/.test(location.protocol)) {
+      <!-- BEGIN Tynt Script -->
+      var Tynt=Tynt||[];Tynt.push('dSm5i4oRer4BQKacwqm_6l');
+      (function(){var s=document.createElement('script');s.async="async";s.type="text/javascript";s.src='http://tcr.tynt.com/ti.js';var h=document.getElementsByTagName('script')[0];h.parentNode.insertBefore(s,h);})();
+    }

--- a/app/views/layouts/partials/snippets/_accessibility.html.haml
+++ b/app/views/layouts/partials/snippets/_accessibility.html.haml
@@ -1,7 +1,8 @@
-.accessibility(aria-label="Page quick links")
-  %a.go(href="#container")
-    go to content
-  %a.go(href="#search-box")
-    go to search box
-  %a.go(href="#global-nav")
-    go to global site navigation
+- cache [__FILE__] do
+  .accessibility(aria-label="Page quick links")
+    %a.go(href="#container")
+      go to content
+    %a.go(href="#search-box")
+      go to search box
+    %a.go(href="#global-nav")
+      go to global site navigation

--- a/app/views/layouts/partials/snippets/_footer_about.html.haml
+++ b/app/views/layouts/partials/snippets/_footer_about.html.haml
@@ -1,42 +1,43 @@
-.row.row--footer--about(role="contentinfo")
-  .row__inner.row__inner--full-width
-    .wv--split--left.nav--inline
-      %a.wv--inline-block.nav__item.row--footer--about__logo.media--lp-logo.icon--lp-logo(href='http://www.lonelyplanet.com')
-      %nav.nav__item.wv--nav--inline(role="navigation" aria-label="About Lonely Planet" itemscope="itemscope" itemtype="http://schema.org/SiteNavigationElement")
-        %h6.accessibility About Lonely Planet
-        - footer_nav_about_items.each do |item|
-          %a.nav__item.nav__item--about{href: "http://www.lonelyplanet.com#{item[:url]}"}(itemprop="url")<
-            %span(itemprop="name")
-              = item[:title].html_safe
+- cache [__FILE__, local_assigns.map(&:to_s), Rizzo::COMMIT] do
+  .row.row--footer--about(role="contentinfo")
+    .row__inner.row__inner--full-width
+      .wv--split--left.nav--inline
+        %a.wv--inline-block.nav__item.row--footer--about__logo.media--lp-logo.icon--lp-logo(href='http://www.lonelyplanet.com')
+        %nav.nav__item.wv--nav--inline(role="navigation" aria-label="About Lonely Planet" itemscope="itemscope" itemtype="http://schema.org/SiteNavigationElement")
+          %h6.accessibility About Lonely Planet
+          - footer_nav_about_items.each do |item|
+            %a.nav__item.nav__item--about{href: "http://www.lonelyplanet.com#{item[:url]}"}(itemprop="url")<
+              %span(itemprop="name")
+                = item[:title].html_safe
 
-    .wv--split--right
-      .nav--inline.nav--social.split--right__inner
-        %a.wv--hidden.row--footer--social__logo.media--lp-logo.icon--lp-logo(href='http://www.lonelyplanet.com')
-        %nav.nav--social__inner.nav__item(role="navigation" aria-label="Social media links" itemscope="itemscope" itemtype="http://schema.org/SiteNavigationElement")
-          %h6.accessibility Social media links
-          .nav--inline
-            - social_media_nav.each do |item|
-              %a.nav__item.nav__item--social{href: "#{item[:url]}", class: "icon--#{item[:title]}"}(itemprop="url")
-                %span(itemprop="name")
-                  = item[:title].capitalize
+      .wv--split--right
+        .nav--inline.nav--social.split--right__inner
+          %a.wv--hidden.row--footer--social__logo.media--lp-logo.icon--lp-logo(href='http://www.lonelyplanet.com')
+          %nav.nav--social__inner.nav__item(role="navigation" aria-label="Social media links" itemscope="itemscope" itemtype="http://schema.org/SiteNavigationElement")
+            %h6.accessibility Social media links
+            .nav--inline
+              - social_media_nav.each do |item|
+                %a.nav__item.nav__item--social{href: "#{item[:url]}", class: "icon--#{item[:title]}"}(itemprop="url")
+                  %span(itemprop="name")
+                    = item[:title].capitalize
 
-.row.row--smallprint
-  .row__inner.row__inner--footer.row--smallprint__inner
-    .wv--split--left.text--legal.copy--disclaimer
-      %p
-        &copy;
-        = Time.now.year
-        Lonely Planet. All rights reserved. No part of this site may be reproduced without our written permission.
+  .row.row--smallprint
+    .row__inner.row__inner--footer.row--smallprint__inner
+      .wv--split--left.text--legal.copy--disclaimer
+        %p
+          &copy;
+          = Time.now.year
+          Lonely Planet. All rights reserved. No part of this site may be reproduced without our written permission.
 
-    - if language_select
-      :ruby
-        dropdown = { id: "languageSelect", name: "language", options: [], data: { form_submit: "true" } }
-        language_options.each do |d|
-          dropdown[:options].push({ title: d[1].html_safe, value: d[0] })
-        end
+      - if language_select
+        :ruby
+          dropdown = { id: "languageSelect", name: "language", options: [], data: { form_submit: "true" } }
+          language_options.each do |d|
+            dropdown[:options].push({ title: d[1].html_safe, value: d[0] })
+          end
 
-      .wv--split--right.form--international
-        .split--right__inner.nav--inline.form--language.media
-          %label.nav__item.form--language__label.title--footer.media__img International
-          .media__body
-            = ui_component('navigation/dropdown', properties: { action: "http://www.lonelyplanet.com/international", dropdown: dropdown })
+        .wv--split--right.form--international
+          .split--right__inner.nav--inline.form--language.media
+            %label.nav__item.form--language__label.title--footer.media__img International
+            .media__body
+              = ui_component('navigation/dropdown', properties: { action: "http://www.lonelyplanet.com/international", dropdown: dropdown })

--- a/app/views/layouts/partials/snippets/_footer_sitemap.html.haml
+++ b/app/views/layouts/partials/snippets/_footer_sitemap.html.haml
@@ -1,87 +1,89 @@
-%nav.row.row--sitemap#js-footer-nav(role="navigation" aria-label="Sitemap" itemscope="itemscope" itemtype="http://schema.org/SiteNavigationElement")
-  %h6.accessibility Sitemap
-  .row__inner.row--sitemap__inner.row__inner--full-width
+- cache [__FILE__, local_assigns.map(&:to_s), Rizzo::COMMIT] do
+  %nav.row.row--sitemap#js-footer-nav(role="navigation" aria-label="Sitemap" itemscope="itemscope" itemtype="http://schema.org/SiteNavigationElement")
+    %h6.accessibility Sitemap
+    .row__inner.row--sitemap__inner.row__inner--full-width
 
-    .col--footer--last
-      %span.title--footer.title--list--footer
-        Newsletter sign up
-      %p.nav__item--footer
-        %strong
-          Subscribe now
-        and receive a
-        %strong
-          20% discount
-        on your next guidebook purchase
-      %form.newsletter--footer(action='http://www.lonelyplanet.com/newsletter/form-submission.php' method='post')
-        %label.polyfill--placeholder.newsletter--placeholder Email
-        %input.input--small--newsletter(type='text' id='newsletter-email' autocomplete='off' name='sailthru_email' placeholder='your@email.com' required='required')
-        %input(type='hidden' name='Source' value='homepagefooter')
-        %input(type='hidden' name='type' value='subscribe')
-        .dropdown.dropdown--country.js-select-group-manager
-          %label.dropdown__value.dropdown__value--country.js-select-overlay.icon--chevron-down--after(for='select-country')
-            Select country
-          %select.dropdown__select.js-select#select-country(name='sailthru_Country')
-            - footer_newsletter_country_items.each do |country|
-              %option(value="#{country[:title]}")
-                = country[:title]
-        %input.btn.btn--green{type: "submit", title: "Subscribe Newsletter", value: "Sign up", data: {lpa_category: "account", lpa_action: "newsletter"}}
 
-    .col--footer
-      %input{type: "checkbox", id: 'ac-destinations', class: "accordion__input"}
-      .nav--stacked.accordion__target.accordion__target--mid
-        %label{for: 'ac-destinations', class: 'accordion__title accordion__title--footer icon--chevron-down--after'}
-        %a.js-nav-item.title--footer.title--list--footer(href='http://www.lonelyplanet.com/destinations' itemprop="url")
-          %span(itemprop="name")
-            Destinations
-        - footer_nav_destination_items.each do |destination|
-          %a.js-nav-item.nav__item.nav__item--sitemap.nav__item--footer{href: "http://www.lonelyplanet.com/#{destination[:url]}"}(itemprop="url")<
+      .col--footer--last
+        %span.title--footer.title--list--footer
+          Newsletter sign up
+        %p.nav__item--footer
+          %strong
+            Subscribe now
+          and receive a
+          %strong
+            20% discount
+          on your next guidebook purchase
+        %form.newsletter--footer(action='http://www.lonelyplanet.com/newsletter/form-submission.php' method='post')
+          %label.polyfill--placeholder.newsletter--placeholder Email
+          %input.input--small--newsletter(type='text' id='newsletter-email' autocomplete='off' name='sailthru_email' placeholder='your@email.com' required='required')
+          %input(type='hidden' name='Source' value='homepagefooter')
+          %input(type='hidden' name='type' value='subscribe')
+          .dropdown.dropdown--country.js-select-group-manager
+            %label.dropdown__value.dropdown__value--country.js-select-overlay.icon--chevron-down--after(for='select-country')
+              Select country
+            %select.dropdown__select.js-select#select-country(name='sailthru_Country')
+              - footer_newsletter_country_items.each do |country|
+                %option(value="#{country[:title]}")
+                  = country[:title]
+          %input.btn.btn--green{type: "submit", title: "Subscribe Newsletter", value: "Sign up", data: {lpa_category: "account", lpa_action: "newsletter"}}
+
+      .col--footer
+        %input{type: "checkbox", id: 'ac-destinations', class: "accordion__input"}
+        .nav--stacked.accordion__target.accordion__target--mid
+          %label{for: 'ac-destinations', class: 'accordion__title accordion__title--footer icon--chevron-down--after'}
+          %a.js-nav-item.title--footer.title--list--footer(href='http://www.lonelyplanet.com/destinations' itemprop="url")
             %span(itemprop="name")
-              = destination[:title]
+              Destinations
+          - footer_nav_destination_items.each do |destination|
+            %a.js-nav-item.nav__item.nav__item--sitemap.nav__item--footer{href: "http://www.lonelyplanet.com/#{destination[:url]}"}(itemprop="url")<
+              %span(itemprop="name")
+                = destination[:title]
 
-    .col--footer
-      %input{type: "checkbox", id: 'ac-shop', class: "accordion__input"}
-      .nav--stacked.accordion__target.accordion__target--mid
-        %label{for: 'ac-shop', class: 'accordion__title accordion__title--footer icon--chevron-down--after'}
-        %a.js-nav-item.title--footer.title--list--footer(href='http://www.lonelyplanet.com/shop' itemprop="url")
-          %span(itemprop="name")
-            Shop
-        - footer_nav_shop_items.each do |shop|
-          %a.js-nav-item.nav__item.nav__item--sitemap.nav__item--footer{href: "http://www.lonelyplanet.com/shop/#{shop[:url]}"}(itemprop="url")<
+      .col--footer
+        %input{type: "checkbox", id: 'ac-shop', class: "accordion__input"}
+        .nav--stacked.accordion__target.accordion__target--mid
+          %label{for: 'ac-shop', class: 'accordion__title accordion__title--footer icon--chevron-down--after'}
+          %a.js-nav-item.title--footer.title--list--footer(href='http://www.lonelyplanet.com/shop' itemprop="url")
             %span(itemprop="name")
-              = shop[:title]
+              Shop
+          - footer_nav_shop_items.each do |shop|
+            %a.js-nav-item.nav__item.nav__item--sitemap.nav__item--footer{href: "http://www.lonelyplanet.com/shop/#{shop[:url]}"}(itemprop="url")<
+              %span(itemprop="name")
+                = shop[:title]
 
-    .col--footer
-      %input{type: "checkbox", id: 'ac-thorntree', class: "accordion__input"}
-      .nav--stacked.accordion__target.accordion__target--mid
-        %label{for: 'ac-thorntree', class: 'accordion__title accordion__title--footer icon--chevron-down--after'}
-        %a.js-nav-item.title--footer.title--list--footer(href='http://www.lonelyplanet.com/thorntree' itemprop="url")
-          %span(itemprop="name")
-            Thorn Tree Forum
-        - footer_nav_thorntree_items.each do |thorntree|
-          %a.js-nav-item.nav__item.nav__item--sitemap.nav__item--footer{href: "http://www.lonelyplanet.com/thorntree/#{thorntree[:url]}"}(itemprop="url")<
+      .col--footer
+        %input{type: "checkbox", id: 'ac-thorntree', class: "accordion__input"}
+        .nav--stacked.accordion__target.accordion__target--mid
+          %label{for: 'ac-thorntree', class: 'accordion__title accordion__title--footer icon--chevron-down--after'}
+          %a.js-nav-item.title--footer.title--list--footer(href='http://www.lonelyplanet.com/thorntree' itemprop="url")
             %span(itemprop="name")
-              = thorntree[:title]
+              Thorn Tree Forum
+          - footer_nav_thorntree_items.each do |thorntree|
+            %a.js-nav-item.nav__item.nav__item--sitemap.nav__item--footer{href: "http://www.lonelyplanet.com/thorntree/#{thorntree[:url]}"}(itemprop="url")<
+              %span(itemprop="name")
+                = thorntree[:title]
 
-    .col--footer
-      %input{type: "checkbox", id: 'ac-interests', class: "accordion__input"}
-      .nav--stacked.accordion__target.accordion__target--mid
-        %label{for: 'ac-interests', class: 'accordion__title accordion__title--footer icon--chevron-down--after'}
-        %a.js-nav-item.title--footer.title--list--footer(href='http://www.lonelyplanet.com/interests' itemprop="url")
-          %span(itemprop="name")
-            Interests
-        - footer_nav_interests_items.each do |theme|
-          %a.js-nav-item.nav__item.nav__item--sitemap.nav__item--footer{href: "http://www.lonelyplanet.com/#{theme[:url]}"}(itemprop="url")<
+      .col--footer
+        %input{type: "checkbox", id: 'ac-interests', class: "accordion__input"}
+        .nav--stacked.accordion__target.accordion__target--mid
+          %label{for: 'ac-interests', class: 'accordion__title accordion__title--footer icon--chevron-down--after'}
+          %a.js-nav-item.title--footer.title--list--footer(href='http://www.lonelyplanet.com/interests' itemprop="url")
             %span(itemprop="name")
-              = theme[:title]
+              Interests
+          - footer_nav_interests_items.each do |theme|
+            %a.js-nav-item.nav__item.nav__item--sitemap.nav__item--footer{href: "http://www.lonelyplanet.com/#{theme[:url]}"}(itemprop="url")<
+              %span(itemprop="name")
+                = theme[:title]
 
-    .col--footer
-      %input{type: "checkbox", id: 'ac-bookings', class: "accordion__input"}
-      .nav--stacked.accordion__target.accordion__target--mid
-        %label{for: 'ac-bookings', class: 'accordion__title accordion__title--footer icon--chevron-down--after'}
-        %a.js-nav-item.title--footer.title--list--footer(href='http://www.lonelyplanet.com/bookings' itemprop="url")
-          %span(itemprop="name")
-            Travel Booking
-        - footer_nav_travel_bookings_items.each do |booking|
-          %a.js-nav-item.nav__item.nav__item--sitemap.nav__item--footer{href: "http://www.lonelyplanet.com/#{booking[:url]}"}(itemprop="url")<
+      .col--footer
+        %input{type: "checkbox", id: 'ac-bookings', class: "accordion__input"}
+        .nav--stacked.accordion__target.accordion__target--mid
+          %label{for: 'ac-bookings', class: 'accordion__title accordion__title--footer icon--chevron-down--after'}
+          %a.js-nav-item.title--footer.title--list--footer(href='http://www.lonelyplanet.com/bookings' itemprop="url")
             %span(itemprop="name")
+              Travel Booking
+          - footer_nav_travel_bookings_items.each do |booking|
+            %a.js-nav-item.nav__item.nav__item--sitemap.nav__item--footer{href: "http://www.lonelyplanet.com/#{booking[:url]}"}(itemprop="url")<
+              %span(itemprop="name")
               = booking[:title]

--- a/app/views/layouts/partials/snippets/_head_js.haml
+++ b/app/views/layouts/partials/snippets/_head_js.haml
@@ -12,57 +12,58 @@
     document.createElement('time');
     document.createElement('picture');
 
-:javascript
-  // Setup our namespace
-  window.lp = window.lp || {};
+- cache [__FILE__, 'javascript'] do
+  :javascript
+    // Setup our namespace
+    window.lp = window.lp || {};
 
-  // Allow legacy apps to add their own properties
-  window.lp.tracking = window.lp.tracking || {};
-  window.lp.supports = window.lp.supports || {};
+    // Allow legacy apps to add their own properties
+    window.lp.tracking = window.lp.tracking || {};
+    window.lp.supports = window.lp.supports || {};
 
-  window.lp.analytics = window.lp.analytics || {
-    dataLayer: {},
-    eventBuffer: [],
-    api: {
-      trackEvent: function(data){
-        window.lp.analytics.eventBuffer.push(data);
+    window.lp.analytics = window.lp.analytics || {
+      dataLayer: {},
+      eventBuffer: [],
+      api: {
+        trackEvent: function(data){
+          window.lp.analytics.eventBuffer.push(data);
+        }
       }
-    }
-  };
+    };
 
-  // Utility cookie retrieval function
-  window.lp.getCookie = function (name) {
-    return unescape(document.cookie.replace(new RegExp("(?:(?:^|.*;)\\s*" + escape(name).replace(/[\-\.\+\*]/g, "\\$&") + "\\s*\\=\\s*([^;]*).*$)|^.*$"), "$1")) || null;
-  };
+    // Utility cookie retrieval function
+    window.lp.getCookie = function (name) {
+      return unescape(document.cookie.replace(new RegExp("(?:(?:^|.*;)\\s*" + escape(name).replace(/[\-\.\+\*]/g, "\\$&") + "\\s*\\=\\s*([^;]*).*$)|^.*$"), "$1")) || null;
+    };
 
-  // Test for LocalStorage support (and space)
-  window.lp.supports.localStorage = 'localStorage' in window && (function() {
-    try {
-      localStorage.setItem("test", "test");
-      localStorage.removeItem("test");
-      return true;
-    } catch(e){
-      return false;
-    }
-  }());
+    // Test for LocalStorage support (and space)
+    window.lp.supports.localStorage = 'localStorage' in window && (function() {
+      try {
+        localStorage.setItem("test", "test");
+        localStorage.removeItem("test");
+        return true;
+      } catch(e){
+        return false;
+      }
+    }());
 
-  // Setup js error logging
-  var _trackJs = {
-    customer: '3cd28f4c5df14f6e9fffa815ed7712b0',
-    globalAlias: false,
-    consoleDisplay: true,
-    userId: window.lp.getCookie('lpUid')
-  };
+    // Setup js error logging
+    var _trackJs = {
+      customer: '3cd28f4c5df14f6e9fffa815ed7712b0',
+      globalAlias: false,
+      consoleDisplay: true,
+      userId: window.lp.getCookie('lpUid')
+    };
 
-  // Switch no-js class for js
-  (function(H){H.className=H.className.replace(/\bno-js\b/,'js')})(document.documentElement);
+    // Switch no-js class for js
+    (function(H){H.className=H.className.replace(/\bno-js\b/,'js')})(document.documentElement);
 
-  // Initialise a flamsteed buffer
-  window.lp.fs = {
-    buffer: [],
-    log : function(x){this.buffer.push({e: x})},
-    time: function(x){!!window.performance && !!window.performance.now && this.buffer.push({e: x, t: window.performance.now()})}
-  };
+    // Initialise a flamsteed buffer
+    window.lp.fs = {
+      buffer: [],
+      log : function(x){this.buffer.push({e: x})},
+      time: function(x){!!window.performance && !!window.performance.now && this.buffer.push({e: x, t: window.performance.now()})}
+    };
 
 = yield :head_js
 

--- a/app/views/layouts/partials/snippets/_leaderboard.html.haml
+++ b/app/views/layouts/partials/snippets/_leaderboard.html.haml
@@ -1,5 +1,6 @@
-- unless @hide_leaderboard
-  .row.row--sponsored.row--leaderboard.row--leaderboard--header
-    .ad-leaderboard
-      .ad-leaderboard__inner
-        = ui_component('ads/leaderboard', properties: { targeting: { position: "header" } })
+- cache [__FILE__, @hide_leaderboard] do
+  - unless @hide_leaderboard
+    .row.row--sponsored.row--leaderboard.row--leaderboard--header
+      .ad-leaderboard
+        .ad-leaderboard__inner
+          = ui_component('ads/leaderboard', properties: { targeting: { position: "header" } })

--- a/lib/rizzo/version.rb
+++ b/lib/rizzo/version.rb
@@ -1,3 +1,4 @@
 module Rizzo
   VERSION = "0.9.2"
+  COMMIT = `git log -1 --format="%H"`
 end


### PR DESCRIPTION
Cache key is built in 3 variants:
1) ```"#{__FILE__}"```- when there is no dynamic content at all
2) ```"#{__FILE__}--#{local_assigns.map(&:to_s).join}"``` - when we pass some
control variables
3) same as 2 + ```Rizzo::COMMIT``` - it depends on data provided by helpers,
therefore it can't be invalidated by calculating view digest. It will be
invalidated on each commit.

I've added cache only to responsive layout, other left untouched.

it should not require any changes in client applications.

/cc @Ianfeather @remybach @patientfrenzy 

ignore whitespaces when reviewing, there are actually very few lines changed.