### PR TITLE
Proper usage of `js-` prefix on classes

### DIFF
--- a/app/assets/javascripts/lib/analytics/travel_insurance_omniture.js
+++ b/app/assets/javascripts/lib/analytics/travel_insurance_omniture.js
@@ -31,16 +31,4 @@ require([ "jquery", "lib/analytics/analytics" ], function($, Analytics) {
       window.s.t();
     }
   };
-
-  // The following should really be using `.js-` prepended classes, but that's all in the Landing Pages repo.
-  $(".nomads-links a").on("click", function() {
-    analytics.track({ events: "event42" });
-  });
-
-  $(".article--row a").on("click", function() {
-    window.s.linkTrackVars = "eVar54";
-    window.s.eVar54 = omniCode;
-    window.s.events = "event45";
-    window.s.tl(this, "o", omniCode);
-  });
 });


### PR DESCRIPTION
> This PR must be tested and released in conjunction with Landing Page PR \ https://github.com/lonelyplanet/landing-pages/pull/311

Adding standard `js-` prefix to class where click tracking is needed. Changed `article--row` to `js-card` to be more specific and utilize a `js-` already being used.