### PR TITLE
Tweaked footer breadcrumbs rwd

### DIFF
--- a/app/assets/stylesheets/core/layouts/modern/_breadcrumbs.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_breadcrumbs.sass
@@ -6,9 +6,13 @@
 
 .row--breadcrumbs
   .responsive &
-    padding: 0 10px
+    margin-bottom: 10px
     +respond-to(wide-view)
-      padding: 0
+      margin-bottom: 0
+    .nav--inline
+      padding-left: 24px
+      +respond-to(wide-view)
+        padding-left: 0
 
 .breadcrumbs--icon
   padding-left: 1.2em
@@ -22,7 +26,7 @@
 .nav__item--breadcrumbs
   @extend %left-icon
   padding: 20px 8px 18px 20px
-  line-height: 20px
+  line-height: 24px
   color: $body-copy
   .responsive &
     padding: 5px 8px 0 20px
@@ -39,29 +43,19 @@
   .stack &,
   .nav--inline &
     font-weight: normal
-    padding: 0 0.2em 0 0.65em
+    padding: 0 0.2em 0 0.75em
     &.current
       font-weight: bold
     &:before
       content: '/'
       // This stops the lower-left most part of the / from being cut off.
-      padding: 0 1px
+      padding: 0 0.25em
       top: -0.33em
+      font-weight: normal
     &:first-child
       padding-left: 0
       &:before
         content: ''
-    .responsive &
-      &.current
-        display: inline-block
-        padding-left: 0
-        &:before
-          display: none
-      +respond-to(medium-view)
-        &.current
-          padding-left: 0.65em
-          &:before
-            display: block
 
 // Qualified selector because not all breadcrumbs are links
 // with slugs and should not be underlined
@@ -81,9 +75,10 @@ a.nav__item--breadcrumbs
   height: 24px
   top: -4px
   .responsive &
-    top: 0
-    +respond-to(medium-view)
-      top: -4px
+    margin-left: -24px
+    +respond-to(wide-view)
+      margin-left: 0
+
   .ie7 &
     @extend .nav__item--breadcrumbs
     text-indent: 0

--- a/app/views/components/navigation/_breadcrumbs.html.haml
+++ b/app/views/components/navigation/_breadcrumbs.html.haml
@@ -3,14 +3,15 @@
 .nav--inline{ itemscope: true, itemtype: "http://data-vocabulary.org/Breadcrumb", class: icon_class }
 
   - if properties[:show_home]
-    %a.nav__item.nav__item--breadcrumbs--home.icon--home{href: '/', itemprop:"url"} Home
+    %a.nav__item.nav__item--breadcrumbs--home.icon--home{href: '/', itemprop:"url"}> Home
 
   - properties[:breadcrumbs].each_with_index do |breadcrumb, index|
     - last = properties[:breadcrumbs].length == (index + 1)
 
     - if breadcrumb[:slug] && !last
-      %a.nav__item.js-nav-item.nav__item--breadcrumbs{itemprop: "url", href: "http://www.lonelyplanet.com/#{breadcrumb[:slug]}"}
+      %a.nav__item.js-nav-item.nav__item--breadcrumbs{itemprop: "url", href: "http://www.lonelyplanet.com/#{breadcrumb[:slug]}"}<>
         = breadcrumb[:place]
+      
     - else
-      %span.nav__item.js-nav-item.nav__item--breadcrumbs{class: last ? "current" : false}
+      %span.nav__item.js-nav-item.nav__item--breadcrumbs{class: last ? "current" : false}<>
         = breadcrumb[:place]


### PR DESCRIPTION
Before:

![screenshot 2014-12-19 01 28 48](https://cloud.githubusercontent.com/assets/1451471/5498391/6e64d31e-871e-11e4-86f1-b3197091195f.png)

After:

![screenshot 2014-12-19 01 26 05](https://cloud.githubusercontent.com/assets/1451471/5498390/6e6246f8-871e-11e4-93ba-83edd6ddc084.png)

 \+ fixed disappearing `/` in responsive default breadcrumbs (bug example from Waldorf's gallery):

![screenshot 2015-01-12 16 58 16](https://cloud.githubusercontent.com/assets/1451471/5705848/664dbf76-9a7c-11e4-90af-255de8fe3b1c.png)
