### PR TITLE
Fixed datepicker dropdown hiding behind .wrapper

### DIFF
--- a/app/assets/stylesheets/styleguide.sass
+++ b/app/assets/stylesheets/styleguide.sass
@@ -391,3 +391,6 @@ pre.styleguide.is-open
     position: static
     .price-label
       margin-top: 0
+
+.booking-widget
+  margin-bottom: 220px


### PR DESCRIPTION
Fixed this:

![screenshot 2014-12-30 16 32 56](https://cloud.githubusercontent.com/assets/1451471/5579860/8bef2296-9041-11e4-8e6e-9adffc01b1fb.png)

for `car rentals`, `flights` & `travel insurance` widgets styleguide.