### PR TITLE
Adding a class to allow a left nav item to appear disabled

### DIFF
--- a/app/assets/stylesheets/components/_left_nav.sass
+++ b/app/assets/stylesheets/components/_left_nav.sass
@@ -36,6 +36,7 @@
   &:hover
     text-decoration: none
     background-color: mix($lpblue,#fff,2%)
+
   &:focus
     outline: 0
     background-color: mix($lpblue,#fff,10%)
@@ -52,6 +53,11 @@
   &:last-child
     border-bottom: none
     border-radius: 0 0 4px 4px
+
+  &.disabled
+    color: $disabled
+    cursor: auto
+    opacity: 0.4
 
   &.is-active
     &, &:hover


### PR DESCRIPTION
> Trello issue: https://trello.com/c/6WkjO9OP/617-link-not-working-properly

## Description
The left nav links on The World view were navigating to another view before the JavaScript loaded.  I added the `.disabled` class so that users had the indication that they could not be clicked on.

## Verification Tasks
Test this change with Waldorf pull request https://github.com/lonelyplanet/waldorf/pull/1794