### PR TITLE
If remove responsive primary nav

### DIFF
--- a/app/assets/stylesheets/components/_tags.sass
+++ b/app/assets/stylesheets/components/_tags.sass
@@ -260,7 +260,7 @@
     +z-layer(below)
     position: absolute
     width: 0
-    bottom: 0px
+    bottom: 0
     border: 13px solid $lpblue
   &.tag--horizontal--right
     +tag-curl-right($lpblue)

--- a/app/assets/stylesheets/core/_inputs.sass
+++ b/app/assets/stylesheets/core/_inputs.sass
@@ -62,30 +62,25 @@ input[type="submit"]
 
 .search--primary
   background-color: transparent
-  margin: 10px 0
   position: relative
+  width: 75%
+  margin: 12px auto 0
+
+  +respond-to(wide-view)
+    width: auto
+    margin: 10px 0
+
   @if $is-ie
     float: left
-  .responsive &
-    width: 75%
-    margin: 12px auto 0
-    +respond-to(wide-view)
-      width: auto
-      margin: 10px 0
 
 .search--primary--mobile
-  display: none
-  .responsive &
-    display: block
-    +respond-to(wide-view)
-      display: none
+  +respond-to(wide-view)
+    display: none
 
 .search--primary--wv
-  @extend %inline-block
-  .responsive &
-    display: none
-    +respond-to(wide-view)
-      display: inline-block
+  display: none
+  +respond-to(wide-view)
+    display: inline-block
 
 .search__input--primary
   transition: width 0.2s ease, background-color 0.2s ease
@@ -98,25 +93,26 @@ input[type="submit"]
   vertical-align: top
   &:focus
     color: $body-copy
+    box-shadow: none
     background-color: white
     background-position: right 6px top -24px
     +placeholder
       color: $body-copy
-  .responsive &
+
+  +respond-to(wide-view)
+    width: 150px
     &:focus
-      box-shadow: none
-    +respond-to(wide-view)
       width: 150px
-      &:focus
-        width: 150px
-      +placeholder()
-        text-indent: -9999px
-    +respond-to(larger-than-ipad)
-      width: 150px
-      &:focus
-        width: 200px
-      +placeholder()
-        text-indent: 0px
+    +placeholder()
+      text-indent: -9999px
+
+  +respond-to(larger-than-ipad)
+    width: 150px
+    &:focus
+      width: 200px
+    +placeholder()
+      text-indent: 0px
+
 
   +placeholder()
     color: $row-primary--darker
@@ -124,6 +120,9 @@ input[type="submit"]
   .ie8 &
     line-height: 16px
     padding: 7px 10px
+    width: 100px
+    &:focus
+      width: 100px
 
 .search__input__icon
   @extend %image-replacement

--- a/app/assets/stylesheets/core/_inputs.sass
+++ b/app/assets/stylesheets/core/_inputs.sass
@@ -111,7 +111,7 @@ input[type="submit"]
     &:focus
       width: 200px
     +placeholder()
-      text-indent: 0px
+      text-indent: 0
 
 
   +placeholder()
@@ -120,9 +120,7 @@ input[type="submit"]
   .ie8 &
     line-height: 16px
     padding: 7px 10px
-    width: 100px
-    &:focus
-      width: 100px
+    width: 100px !important
 
 .search__input__icon
   @extend %image-replacement
@@ -165,9 +163,9 @@ input[type="submit"]
       @extend %rounded-corners
       list-style: none
       top: 4px
-      left: 0px
+      left: 0
       width: 100%
-      margin: 0px
+      margin: 0
       background-color: white
       position: absolute
       background-color: white
@@ -175,7 +173,7 @@ input[type="submit"]
       +css-arrow-central(top, $size: 30px)
       &:after
         position: absolute
-        filter: drop-shadow(0 -1px 0px rgba(0,0,0,.3))
+        filter: drop-shadow(0 -1px 0 rgba(0,0,0,.3))
       .btn--small
         width: 90%
         margin: 13px auto
@@ -199,7 +197,7 @@ input[type="submit"]
         position: relative
         text-decoration: none
         &:last-child
-          border: 0px
+          border: 0
         &:before
           width: 20px
           height: 20px

--- a/app/assets/stylesheets/core/_layout.sass
+++ b/app/assets/stylesheets/core/_layout.sass
@@ -10,16 +10,13 @@ body
 
 .grid--main-layout
 
-  .responsive &
-    margin-left: 0
+  +respond-to(wide-view)
+    margin-left: -10px
+
+  > [class*="col--"]
+    padding-left: 0
     +respond-to(wide-view)
-      margin-left: -10px
-
-    > [class*="col--"]
-      padding-left: 0
-      +respond-to(wide-view)
-        padding-left: 10px
-
+      padding-left: 10px
 
 // ----------------------------------------------------------------------------
 //
@@ -83,21 +80,14 @@ body
 // ----------------------------------------------------------------------------
 
 .row--faux-banner
-  display: none
-  .responsive &
-    display: block
-    position: absolute
-    top: 0
-    left: 0
-    right: 0
-    background-color: $navblue
-    height: $primary-nav-height
-    +respond-to(wide-view)
-      display: none
-  .minimal &
-    +respond-to(wide-view)
-      display: block
-
+  position: absolute
+  top: 0
+  left: 0
+  right: 0
+  background-color: $navblue
+  height: $primary-nav-height
+  +respond-to(wide-view)
+    display: none
 
 // ----------------------------------------------------------------------------
 //
@@ -107,11 +97,10 @@ body
 
 .row--content
   +z-layer
-  margin-bottom: 40px
+  @extend %transition--nav
   // Ensure that nav dropdowns sit above any content
   position: relative
-  .responsive &
-    @extend %transition--nav
+  margin-bottom: 40px
 
 
 // ----------------------------------------------------------------------------

--- a/app/assets/stylesheets/core/core_components/_accordion.sass
+++ b/app/assets/stylesheets/core/core_components/_accordion.sass
@@ -62,7 +62,7 @@
   max-height: 40px
 
 .accordion__target--closed
-  max-height: 0px
+  max-height: 0
 
 .accordion__target--large
   max-height: 300px

--- a/app/assets/stylesheets/core/core_components/_card_layer.sass
+++ b/app/assets/stylesheets/core/core_components/_card_layer.sass
@@ -9,7 +9,7 @@ $layer-max-width: 800px
 .card--layer
   width: 100%
   max-width: $layer-max-width
-  margin: 0px auto
+  margin: 0 auto
 
   .row--billboard
     width: 100%
@@ -30,8 +30,8 @@ $layer-max-width: 800px
       padding-top: 1px
       &:before
         +size(24px)
-        top: 0px
-        left: 0px
+        top: 0
+        left: 0
 
 .card--layer__content
   @extend %clearfix

--- a/app/assets/stylesheets/core/core_components/_place_title.sass
+++ b/app/assets/stylesheets/core/core_components/_place_title.sass
@@ -25,7 +25,7 @@ $submenu-item-padding: 11px 10px 10px 50px
       +size(12px)
       position: absolute
       top: 8px
-      right: 0px
+      right: 0
       margin-top: 0
       +respond-to(wide-view)
         display: block

--- a/app/assets/stylesheets/core/layouts/legacy/_overrides.sass
+++ b/app/assets/stylesheets/core/layouts/legacy/_overrides.sass
@@ -55,6 +55,7 @@ ul
 
 .row--primary
   @extend %lp-font-stack
+  position: relative
   min-width: 1020px
   margin-bottom: 0 !important
   z-index: 20
@@ -375,3 +376,12 @@ body
 
 [class^="badge--"]
   font-size: 11px
+
+// Hide the last primary nav item in small/screen + non-responsive
+// This is only relevant for non-responsive pages.
+.nav__item--primary
+  .nav--primary:last-child
+    display: none
+
+    +respond-to(1050)
+      display: inline-block

--- a/app/assets/stylesheets/core/layouts/legacy/_overrides.sass
+++ b/app/assets/stylesheets/core/layouts/legacy/_overrides.sass
@@ -57,7 +57,6 @@ ul
   @extend %lp-font-stack
   position: relative
   min-width: 1020px
-  margin-bottom: 0 !important
   z-index: 20
 
 .row--secondary
@@ -114,7 +113,7 @@ ul
     background: inherit !important
 
 .row__inner--content
-  padding: 0px!important
+  padding: 0!important
 
 .btn-submit--small
   padding: 8px 10px
@@ -243,7 +242,7 @@ body.ad-wallpaper
 
 .shop
   .nav__submenu__link
-    border: 0px !important
+    border: 0 !important
     border-bottom: 1px solid #DBE6EC !important
 
 // Statler

--- a/app/assets/stylesheets/core/layouts/modern/_ads.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_ads.sass
@@ -4,14 +4,14 @@
 
 .row--sponsored
   transition: height 0.5s ease
-  min-height: 100px
+  min-height: 60px
   overflow: hidden
   width: 100%
+  &.row--leaderboard
+    transition: height 0.5s ease, transform 0.4s ease
 
-  .responsive &
-    min-height: 60px
-    +respond-to(728)
-      min-height: 100px
+  +respond-to(728)
+    min-height: 100px
 
   &.is-closed
     min-height: 0
@@ -22,17 +22,10 @@
 // Site leaderboard
 // ----------------------------------------------------------------------------
 
-.row--leaderboard
-  .responsive &
-    @extend %transition--nav
-
 .ad-leaderboard
-  padding: 16px 0
-
-  .responsive &
-    padding: 12px 0
-    +respond-to(728)
-      padding: 16px 0
+  padding: 12px 0
+  +respond-to(728)
+    padding: 16px 0
 
 .ad-leaderboard__inner
   position: relative
@@ -75,13 +68,10 @@
   background: darken($body-background, 2.5%)
 
 .ad-billboard
-  padding: 20px 0
+  padding: 12px 0
   text-align: center
-
-  .responsive &
-    padding: 12px 0
-    +respond-to(728)
-      padding: 20px 0
+  +respond-to(728)
+    padding: 20px 0
 
 .ad-billboard__inner
   display: inline-block

--- a/app/assets/stylesheets/core/layouts/modern/_ads.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_ads.sass
@@ -6,7 +6,6 @@
   transition: height 0.5s ease
   min-height: 60px
   overflow: hidden
-  width: 100%
   &.row--leaderboard
     transition: height 0.5s ease, transform 0.4s ease
 

--- a/app/assets/stylesheets/core/layouts/modern/_cookie_compliance.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_cookie_compliance.sass
@@ -10,10 +10,10 @@
   background-color: $dark-blue-gray
   overflow: hidden
   color: #fff
-  .responsive &
-    text-align: center
-    +respond-to(wide-view)
-      text-align: left
+  text-align: center
+  +respond-to(wide-view)
+    text-align: left
+
   .split--left
     max-width: 75%
 
@@ -26,13 +26,11 @@
     font-weight: bold
 
   .cookie-buttons
-    padding-top: 7px
-    .responsive &
-      padding-top: 0
-      text-align: center
-      +respond-to(wide-view)
-        padding-top: 7px
-        text-align: right
+    padding-top: 0
+    text-align: center
+    +respond-to(wide-view)
+      padding-top: 7px
+      text-align: right
 
   .btn
     +font-size(12)

--- a/app/assets/stylesheets/core/layouts/modern/_nav_flyout.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_nav_flyout.sass
@@ -38,7 +38,6 @@ $submenu__vertical-padding: 14px
 // padding around the submenu gives the submenu flyout more area to hover over
 .nav__submenu
   +z-layer(middle)
-  position: static
   display: none
 
   // Centralise the submenu relative to its parent

--- a/app/assets/stylesheets/core/layouts/modern/_nav_flyout.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_nav_flyout.sass
@@ -17,20 +17,16 @@ $submenu__vertical-padding: 14px
   position: relative
   &:hover
     .nav__submenu
+      display: none
+      +respond-to(wide-view)
+        display: block
+
+  &.is-visible
+    .nav__submenu
       display: block
+
   > .nav__item
     display: block
-
-  .responsive &
-    &:hover
-      .nav__submenu
-        display: none
-        +respond-to(wide-view)
-          display: block
-
-    &.is-visible
-      .nav__submenu
-        display: block
 
 .nav__submenu__trigger--icon
   +size(15px)
@@ -42,86 +38,73 @@ $submenu__vertical-padding: 14px
 // padding around the submenu gives the submenu flyout more area to hover over
 .nav__submenu
   +z-layer(middle)
-  position: absolute
+  position: static
   display: none
-  width: $submenu--width
-  padding: $submenu__padding
+
   // Centralise the submenu relative to its parent
   left: 50%
   top: 54%
-  margin-left: $submenu__left-offset
 
   // `.responsive &` needed to override specificity for now
   &.place-title__submenu, .responsive &.place-title__submenu
     top: 25px
     padding-top: 5px
 
-  .responsive &
-    margin-left: 0
-    padding: 0
-    position: static
-    width: auto
-    +respond-to(wide-view)
-      position: absolute
-      padding: $submenu__padding
-      margin-left: $submenu__left-offset
-      width: $submenu--width
+  +respond-to(wide-view)
+    position: absolute
+    padding: $submenu__padding
+    margin-left: $submenu__left-offset
+    width: $submenu--width
 
 .nav__submenu__content
   +css-arrow-central(top, $size: 30px)
   @extend %transition--base
-  @extend %fly-out-shadow
   @extend %rounded-corners
-  background-color: white
   position: relative
-  .row--secondary &
-    border-top: 1px solid $subduedgray
+  display: none
+  background-color: white
   &:after
     position: absolute
+    display: none
     filter: drop-shadow(0 -1px 0 rgba(0, 0, 0, 0.1))
+
+  +respond-to(wide-view)
+    // We can't use `@extend %fly-out-shadow` within a mixin, thus:
+    box-shadow: 0 2px 2px 0 rgba($darkgray,0.25)
+    &, &:after
+      display: block
+
+  .row--secondary &
+    border-top: 1px solid $subduedgray
 
   .place-title__submenu &
     +css-arrow-central(top, $size: 20px)
 
-  .responsive &
-    box-shadow: none
-    &, &:after
-      display: none
-    +respond-to(wide-view)
-      // We can't use `@extend %fly-out-shadow` within a mixin, thus:
-      box-shadow: 0 2px 2px 0 rgba($darkgray,0.25)
-      &, &:after
-        display: block
-
 .nav__submenu__item
   color: $body-copy
   font-weight: normal
-  padding: $submenu__padding__item
-  text-transform: none
+  padding: $submenu__vertical-padding 20px
+  text-transform: uppercase
   border-bottom: 1px solid $subduedgray
+  background-color: $responsive-nav-subnav-bg
+  &:hover
+    color: $lpblue
+
   &:first-child
     border-radius: 4px 4px 0 0
     overflow: hidden
+
   &:last-child
     border-bottom: 0
     border-radius: 0 0 4px 4px
-  &:hover
-    background-color: $body-background-offset
 
-  .responsive &
-    padding: $submenu__vertical-padding 20px
-    text-transform: uppercase
-    background-color: $responsive-nav-subnav-bg
+  +respond-to(wide-view)
+    background-color: transparent
+    padding: $submenu__padding__item
+    text-transform: none
     &:hover
-      color: $lpblue
-
-    +respond-to(wide-view)
-      background-color: transparent
-      padding: $submenu__padding__item
-      text-transform: none
-      &:hover
-        background-color: $body-background-offset
-        color: $body-copy
+      background-color: $body-background-offset
+      color: $body-copy
 
   .nav__item__badge
     float: right

--- a/app/assets/stylesheets/core/layouts/modern/_primary_nav.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_primary_nav.sass
@@ -146,11 +146,9 @@
     display: none
 
 .nav__item--user-menu--wv
-  display: inline
-  .responsive &
-    display: none
-    +respond-to(wide-view)
-      display: inline
+  display: none
+  +respond-to(wide-view)
+    display: inline
 
 .nav__item--primary
   &.sign_up

--- a/app/assets/stylesheets/core/layouts/modern/_primary_nav.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_primary_nav.sass
@@ -6,10 +6,8 @@
 
 .row--primary
   +z-layer(middle)
-  position: relative
-  .responsive &
-    position: static
-    margin-bottom: $primary-nav-height
+  position: static
+  margin-bottom: $primary-nav-height
 
 // ----------------------------------------------------------------------------
 //
@@ -51,69 +49,58 @@
 
 .nav--primary
   // Move the nav to the right of the absolutely positioned logo
-  margin-left: 117px
-  .responsive &
-    margin-left: 0
-    +respond-to(wide-view)
-      margin-left: 117px
+  margin-left: 0
+  +respond-to(wide-view)
+    margin-left: 117px
 
 .nav__item--primary
-  +font-size(13)
-  padding: 21px 4px 18px
-  text-transform: uppercase
-  &.btn--small
-    &, .responsive &
-      +font-size(13)
-      margin: 13px 6px 10px 0
-      padding: 2px 12px
-  .responsive &
-    +font-size(18)
-    padding: 17px 10px
-    border-bottom: 1px solid $offscreen-nav-border
-    position: relative
-    text-transform: none
+  +font-size(18)
+  padding: 17px 10px
+  border-bottom: 1px solid $offscreen-nav-border
+  position: relative
+  text-transform: none
+  &:before
+    @extend %empty-abs-generated-content
+    width: 50px
+    border-right: 1px solid $offscreen-nav-border
+    display: block
+    left: 0
+    top: 0
+    height: 100%
+    color: $offscreen-nav-border
+    background-position: center
+    background-size: 40%
+
+  +respond-to(wide-view)
+    +font-size(13)
+    padding: 21px 4px 18px
+    border: none
+    text-transform: uppercase
     &:before
-      @extend %empty-abs-generated-content
-      width: 50px
-      border-right: 1px solid $offscreen-nav-border
-      display: block
-      left: 0
-      top: 0
-      height: 100%
-      color: $offscreen-nav-border
-      background-position: center
-      background-size: 40%
-    +respond-to(wide-view)
-      +font-size(13)
-      padding: 21px 4px 18px
+      width: 0
       border: none
-      text-transform: uppercase
-      &:before
-        width: 0
-        border: none
+
+  &.btn--small
+    +font-size(13)
+    margin: 13px 6px 10px 0
+    padding: 2px 12px
 
   &, & > .nav__item
-    font-weight: bold
     color: $nav-primary-type
-    .responsive &
-      font-weight: normal
-      +respond-to(wide-view)
-        font-weight: bold
+    font-weight: normal
+    +respond-to(wide-view)
+      font-weight: bold
+
+  .nav--primary &:last-child
+    +respond-to(970)
+      display: none
+
+    +respond-to(1050)
+      display: inline-block
 
   .nav__item--primary--signout--mobile
     +respond-to(wide-view)
       display: none
-
-  // Hide the last primary nav item in small/screen + non-responsive
-  // This is only relevant for non-responsive pages.
-  // Move to _overrides when only legacy is fixed-width
-  .nav--primary &:last-child
-    display: none
-    .responsive &
-      display: inline-block
-
-    +respond-to(1050)
-      display: inline-block
 
 .nav__item--sign-in,
 .nav__item--join
@@ -129,45 +116,34 @@
 .nav--primary--user
   margin-right: 20px
 
-  .responsive.show-nav &
+  .show-nav &
     margin-right: 0
 
 .nav__item--user
   color: $nav-primary-type
-  margin-top: 10px
   padding-right: 25px
+  margin-top: 0
+  height: 50px
+  +respond-to(990)
+    background: none
+  +respond-to(wide-view)
+    margin-top: 10px
+    height: auto
+
   &:hover
     color: #fff
-  .responsive &
-    margin-top: 0
-    height: 50px
-    +respond-to(990)
-      background: none
-    +respond-to(wide-view)
-      margin-top: 10px
-      height: auto
+
 
 .nav__item--user-avatar
-  border-radius: 17px
-  height: 34px
-  width: 34px
-  .responsive &
-    border-radius: 0px
-    height: 50px
-    width: 50px
-    +respond-to(wide-view)
-      border-radius: 17px
-      height: 34px
-      width: 34px
+  +size(50px)
+  +respond-to(wide-view)
+    +size(34px)
+    border-radius: 17px
 
 .nav__item--user-menu
   background: $offscreen-nav-user-background
-  display: none
-
-  .responsive &
-    display: block
-    +respond-to(wide-view)
-      display: none
+  +respond-to(wide-view)
+    display: none
 
 .nav__item--user-menu--wv
   display: inline
@@ -175,6 +151,7 @@
     display: none
     +respond-to(wide-view)
       display: inline
+
 .nav__item--primary
   &.sign_up
     color: white
@@ -211,8 +188,6 @@
 
 .nav--primary--user .nav__icon
   .nav__icon
-    padding-left: 0
-    .responsive &
-      padding-left: 60px
-      +respond-to(wide-view)
-        padding: 0
+    padding-left: 60px
+    +respond-to(wide-view)
+      padding: 0

--- a/app/assets/stylesheets/core/layouts/modern/_primary_nav.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_primary_nav.sass
@@ -63,7 +63,6 @@
     @extend %empty-abs-generated-content
     width: 50px
     border-right: 1px solid $offscreen-nav-border
-    display: block
     left: 0
     top: 0
     height: 100%

--- a/app/assets/stylesheets/core/layouts/modern/_responsive_nav.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_responsive_nav.sass
@@ -13,33 +13,29 @@ $responsive-nav-width: 240px
 // The container for our off-screen navigation
 .nav-container
   +hardware-acceleration()
+  +z-layer(middle)
   backface-visibility: hidden
   @extend %clearfix
-  width: 100%
-  background: $navblue
-  overflow: visible
-  height: $primary-nav-height
-  .responsive &
-    +z-layer(middle)
-    @extend %transition--nav
-    position: absolute
-    overflow: hidden
-    top: 0
-    right: -$responsive-nav-width
-    width: $responsive-nav-width
-    height: 100%
-    background: $offscreen-nav-background
+  @extend %transition--nav
+  position: absolute
+  overflow: hidden
+  top: 0
+  right: -$responsive-nav-width
+  width: $responsive-nav-width
+  height: 100%
+  background: $offscreen-nav-background
+  .enhanced &
+    box-shadow: 16px 4px 20px -6px rgba(0, 0, 0, 0.2) inset
+
+  +respond-to(wide-view)
+    width: 100%
+    background: $navblue
+    overflow: visible
+    height: $primary-nav-height
+    left: 0
+    right: auto
     .enhanced &
-      box-shadow: 16px 4px 20px -6px rgba(0, 0, 0, 0.2) inset
-    +respond-to(wide-view)
-      width: 100%
-      background: $navblue
-      overflow: visible
-      height: $primary-nav-height
-      left: 0
-      right: auto
-      .enhanced &
-        box-shadow: none
+      box-shadow: none
 
 .nav--offscreen__title
   +font-size(20)

--- a/app/assets/stylesheets/core/layouts/modern/_shopping_cart.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_shopping_cart.sass
@@ -4,7 +4,6 @@
 //
 // ----------------------------------------------------------------------------
 
-.responsive .user-basket,
 .user-basket
   position: relative
   margin-left: 5px

--- a/app/assets/stylesheets/core/layouts/modern/_shopping_cart.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_shopping_cart.sass
@@ -9,7 +9,7 @@
   position: relative
   margin-left: 5px
   padding: 4px 8px
-  .responsive .wv--nav--inline > &.nav__item
+  .wv--nav--inline > &.nav__item
     display: none
     +respond-to(wide-view)
       display: inline-block

--- a/app/assets/stylesheets/core/layouts/modern/_user_feed.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_user_feed.sass
@@ -83,9 +83,8 @@
       padding-bottom: 5px
     .activity-list__time
       position: absolute
-      bottom: 0
-      left: 0
-      margin: 0 0 15px 15px
+      bottom: 15px
+      left: 15px
       color: $bodygray
       &:before
         +size(1.1em)

--- a/app/assets/stylesheets/core/layouts/modern/_user_feed.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_user_feed.sass
@@ -7,8 +7,7 @@
 .user-feed,
   left: -200px
   cursor: default
-  &, .responsive & // because .nav__submenu overwrites width when .responsive used
-    width: 360px 
+  width: 360px
 
 .user-feed__container
   +css-arrow(top, 30px, 317px)
@@ -83,12 +82,11 @@
       display: block
       padding-bottom: 5px
     .activity-list__time
-      &, .responsive & // same as above
-        position: absolute
-        bottom: 0
-        left: 0
-        margin: 0 0 15px 15px
-        color: $bodygray
+      position: absolute
+      bottom: 0
+      left: 0
+      margin: 0 0 15px 15px
+      color: $bodygray
       &:before
         +size(1.1em)
         display: inline-block

--- a/app/assets/stylesheets/core/utilities/_responsive.sass
+++ b/app/assets/stylesheets/core/utilities/_responsive.sass
@@ -19,158 +19,122 @@
 
 // [doc] Hide content on wider screens. [/doc]
 .wv--hidden
-  display: none
-  .responsive &
-    display: inline-block
-    +respond-to(wide-view)
-      display: none !important
+  display: inline-block
+  +respond-to(wide-view)
+    display: none !important
 
 // [doc] Hide content on wide screens (shows with block properties). [/doc]
 .wv--hidden-block
-  display: none
-  .responsive &
-    display: block
-    +respond-to(wide-view)
-      display: none !important
+  display: block
+  +respond-to(wide-view)
+    display: none !important
 
 // [doc] Hide :before content on wide screens
 .wv--hidden--before
   &:before
-    display: none
-    .responsive &
-      display: block
-      +respond-to(wide-view)
-        display: none !important
+    display: block
+    +respond-to(wide-view)
+      display: none !important
 
 // [doc] Hide :after content on wide screens
 .wv--hidden--after
   &:after
-    display: none
-    .responsive &
-      display: block
-      +respond-to(wide-view)
-        display: none !important
+    display: block
+    +respond-to(wide-view)
+      display: none !important
 
 // [doc] Hide content but show it on wider screens. [/doc]
 .wv--block
-  display: block
-  .responsive &
-    display: none
-    +respond-to(wide-view)
-      display: block
+  display: none
+  +respond-to(wide-view)
+    display: block
 
 // [doc] Hide content but show it on wider screens (with inline-block properties). [/doc]
 .wv--inline-block
-  @extend %inline-block
-  .responsive &
-    display: none
-    +respond-to(wide-view)
-      display: inline-block
+  display: none
+  +respond-to(wide-view)
+    display: inline-block
 
 // [doc] Hide content but show it on wider screens (with display:table properties). [/doc]
 .wv--table
-  display: table-cell
-  .responsive &
-    display: none
-    +respond-to(wide-view)
-      display: table-cell
+  display: none
+  +respond-to(wide-view)
+    display: table-cell
 
 // [doc] Toggles a stacked nav to an inline nav for wider screens. [/doc]
 .wv--nav--inline
-  .responsive &
+  > .nav__item
+    display: block
+  +respond-to(wide-view)
+    display: inline-block
     > .nav__item
-      display: block
-    +respond-to(wide-view)
+      vertical-align: top
       display: inline-block
-      > .nav__item
-        vertical-align: top
-        display: inline-block
-    .ie7 &
-      .nav__item
-        float: left
+
+  .ie7 &
+    .nav__item
+      float: left
 
 // [doc] Floats content left but only on wider screens. [/doc]
 .wv--split--left
-  float: left
-  .responsive &
-    float: none
-    +respond-to(wide-view)
-      float: left
+  float: none
+  +respond-to(wide-view)
+    float: left
 
 // [doc] Floats content right but only on wider screens. [/doc]
 .wv--split--right
-  float: right
-  text-align: right
-  .responsive &
-    float: none
-    text-align: left
-    +respond-to(wide-view)
-      float: right
-      text-align: right
+  float: none
+  text-align: left
+  +respond-to(wide-view)
+    float: right
+    text-align: right
 
 // [doc] Hide content on medium screens. [/doc]
 .mv--hidden
-  display: none
-  .responsive &
-    display: inline-block
-    +respond-to(medium-view)
-      display: none
+  display: inline-block
+  +respond-to(medium-view)
+    display: none
 
 // [doc] Hide content on medium screens (shows with block properties). [/doc]
 .mv--hidden-block
-  display: none
-  .responsive &
-    display: block
-    +respond-to(medium-view)
-      display: none
+  display: block
+  +respond-to(medium-view)
+    display: none
 
 // [doc] Hide content but show it on medium screens. [/doc]
 .mv--block
-  display: block
-  .responsive &
-    display: none
-    +respond-to(medium-view)
-      display: block
+  display: none
+  +respond-to(medium-view)
+    display: block
 
 // [doc] Hide content but show it on medium screens (with inline properties). [/doc]
 .mv--inline
-  display: inline
-  .responsive &
-    display: none
-    +respond-to(medium-view)
-      display: inline
+  display: none
+  +respond-to(medium-view)
+    display: inline
 
 // [doc] Hide content but show it on medium screens (with inline-block properties). [/doc]
 .mv--inline-block
-  @extend %inline-block
-  .responsive &
-    display: none
-    +respond-to(medium-view)
-      display: inline-block
+  display: none
+  +respond-to(medium-view)
+    display: inline-block
 
 // [doc] Hide content but show it on medium screens (with display:table properties). [/doc]
 .mv--table
-  display: table-cell
-  .responsive &
-    display: none
-    +respond-to(medium-view)
-      display: table-cell
+  display: none
+  +respond-to(medium-view)
+    display: table-cell
 
 // [doc] Floats content left but only on medium screens. [/doc]
 .mv--split--left
-  float: left
-  .responsive &
-    float: none
-    +respond-to(medium-view)
-      float: left
+  float: none
+  +respond-to(medium-view)
+    float: left
 
 // [doc] Floats content right but only on medium screens. [/doc]
 .mv--split--right
-  float: right
-  text-align: right
-  .responsive &
-    float: none
-    text-align: left
-    +respond-to(medium-view)
-      float: right
-      text-align: right
+  float: none
+  text-align: left
+  +respond-to(medium-view)
+    float: right
+    text-align: right

--- a/app/assets/stylesheets/sass/extends/lp_styles/_decoration.sass
+++ b/app/assets/stylesheets/sass/extends/lp_styles/_decoration.sass
@@ -22,12 +22,12 @@
 // [doc] The standard shadow used on flyouts - dropdowns, datepickers etc. [/doc]
 %fly-out-shadow
   .enhanced &
-    box-shadow: 0 2px 2px 0px rgba($darkgray,0.25)
+    box-shadow: 0 2px 2px 0 rgba($darkgray,0.25)
 
 // [doc] The large shadow used on popup box. [/doc]
 %large-shadow
   .enhanced &
-    box-shadow: 0px 2px 4px 0px rgba($darkgray, 0.15)
+    box-shadow: 0 2px 4px 0 rgba($darkgray, 0.15)
 
 // [doc] The standard rounded corner used on tabs, buttons etc. [/doc]
 %rounded-corners

--- a/app/assets/stylesheets/widgets/_booking.sass
+++ b/app/assets/stylesheets/widgets/_booking.sass
@@ -70,7 +70,7 @@
     margin: 0 10px 0 3px
 
 .date-group--booking
-  padding: 0px
+  padding: 0
   margin: 12px 0
 
 .dropdown--booking


### PR DESCRIPTION
Removing all the instances of `.responsive` is a hairy task so taking it piece by piece. This is just for the primary nav.

The code is pretty tricky to review, though still worth a look, easiest might be to pull it down. To test, remove the `responsive` class from `body` in `responsive.html.haml`.

The responsive class will be removed finally once it's all been removed from the css.

![image](https://cloud.githubusercontent.com/assets/814861/5857588/de796dd6-a244-11e4-850d-eff9a7d8a41b.png)

![image](https://cloud.githubusercontent.com/assets/814861/5857591/e7253e1a-a244-11e4-949d-40344a161e5e.png)

![image](https://cloud.githubusercontent.com/assets/814861/5857599/f1c98a92-a244-11e4-9138-648547589032.png)


In IE

![image](https://cloud.githubusercontent.com/assets/814861/5857637/42e412b2-a245-11e4-918d-d34e17a6540b.png)

![image](https://cloud.githubusercontent.com/assets/814861/5857648/4fbfebf0-a245-11e4-80a4-72538164ae10.png)


Shop

![image](https://cloud.githubusercontent.com/assets/814861/5857869/c213fb46-a246-11e4-9177-23af26091192.png)
