### PR TITLE
ability deliver media query styles to old browsers

### DIFF
--- a/app/assets/stylesheets/sass/mixins/_responsive.sass
+++ b/app/assets/stylesheets/sass/mixins/_responsive.sass
@@ -12,7 +12,7 @@
 //
 // [/doc]
 // -----------------------------------------------------------------------------
-@mixin respond-to($screen-width, $fallback: true)
+@mixin respond-to($screen-width, $fallback: true, $legacy-support: false)
 
   // We have to set up a blank variable here or sass errors out
   $breakpoint: ''
@@ -37,6 +37,10 @@
 
   @else
     @media only screen and (min-width : #{$breakpoint}px)
+      @content
+
+  @if ($legacy-support)
+    .ie7 &, .ie8 &
       @content
 
 // -----------------------------------------------------------------------------

--- a/app/assets/stylesheets/sass/mixins/_responsive.sass
+++ b/app/assets/stylesheets/sass/mixins/_responsive.sass
@@ -12,7 +12,7 @@
 //
 // [/doc]
 // -----------------------------------------------------------------------------
-@mixin respond-to($screen-width, $fallback: true, $legacy-support: false)
+@mixin respond-to($screen-width, $fallback: true)
 
   // We have to set up a blank variable here or sass errors out
   $breakpoint: ''
@@ -39,9 +39,20 @@
     @media only screen and (min-width : #{$breakpoint}px)
       @content
 
-  @if ($legacy-support)
-    .ie7 &, .ie8 &
-      @content
+// -----------------------------------------------------------------------------
+// [doc]
+//
+// Enable styles at a certain viewport with legacy
+//  .ie7 and .ie8 style output
+//
+//
+// [/doc]
+// -----------------------------------------------------------------------------
+@mixin respond-to-legacy-support($screen-width)
+  +respond-to($screen-width)
+    @content
+  .ie7 &, .ie8 &
+    @content
 
 // -----------------------------------------------------------------------------
 // [doc]


### PR DESCRIPTION
Add an option to output the styles for browsers that do not support media query styles.

For example, we would like to be able to apply the `width` and `display` to IE7/8 in addition to `wide-view` media query block.

```.group--highlight
    +respond-to(wide-view, $fallback: true, $legacy: true)
      width: 50%
      display: block