### PR TITLE
fix date format issue with datepicker label

### DIFF
--- a/app/assets/javascripts/lib/components/datepicker.js
+++ b/app/assets/javascripts/lib/components/datepicker.js
@@ -82,7 +82,7 @@ define([ "jquery", "picker", "pickerDate", "pickerLegacy" ], function($) {
       if (!this._isValidEndDate()) {
         this.outDate.data("pickadate").set("select", new Date(date).getTime() + this.day);
       }
-      this.inLabel.text(date);
+      this.inLabel.text(this.inDate.val());
     } else if (type === "end") {
       if (!this._isValidEndDate() || this.firstTime) {
         this.inDate.data("pickadate").set("select", new Date(date).getTime() - this.day);


### PR DESCRIPTION
Consistently format labels for datepicker.
FROM
![datescreen_shot_2015-01-29_at_18 18 59 1](https://cloud.githubusercontent.com/assets/2614324/6009543/523e6858-aaf0-11e4-8b24-835074062b12.png)

TO
![screen shot 2015-02-02 at 3 31 47 pm](https://cloud.githubusercontent.com/assets/2614324/6009712/eaf528f6-aaf1-11e4-9852-e120e613a21a.png)