### PR TITLE
Fix for `.field__label` & `.field__content` to be actually responsive

### DIFF
--- a/app/assets/stylesheets/core/core_components/_forms.sass
+++ b/app/assets/stylesheets/core/core_components/_forms.sass
@@ -13,25 +13,26 @@
   .input
     float: left
 
+.field__label,
+.field__content
+  @extend %clearfix
+  display: block
+  width: 100%
+  +respond-to(medium-view)
+    float: left
+
 .field__label
   box-sizing: border-box
   padding: 10px 10px 10px 0
-  .field--radio &
-    padding: 0 10px 0 0
   +respond-to(medium-view)
     width: 35%
+
+  .field--radio &
+    padding: 0 10px 0 0
 
 .field__content
   +respond-to(medium-view)
     width: 65%
-
-.field__label,
-.field__content
-  @extend %clearfix
-  display: inline-block
-  width: 100%
-  +respond-to(medium-view)
-    float: left
 
 .field__input--error,
 .field__input--valid


### PR DESCRIPTION
Before these were always 100% wide:
![screenshot 2015-02-04 17 07 35](https://cloud.githubusercontent.com/assets/1451471/6045235/89ec7956-ac90-11e4-953a-8f6d50a341df.png)

Just had to make shared attributes go first. 