### PR TITLE
This makes the map POI in IE8 look better.

### DIFF
--- a/app/assets/stylesheets/components/_poi_list.sass
+++ b/app/assets/stylesheets/components/_poi_list.sass
@@ -5,7 +5,7 @@
   overflow: auto
   background: #fff
 
-  +respond-to(medium-view)
+  +respond-to-legacy-support(medium-view)
     position: absolute
     top: 12px
     right: 12px
@@ -14,7 +14,7 @@
     max-width: 50%
 
   .is-closed &
-    +respond-to(medium-view)
+    +respond-to-legacy-support(medium-view)
       display: none
 
   &::-webkit-scrollbar


### PR DESCRIPTION
##### This is an IE8 bug fix.  
 The POI descriptions currently have a transparent background and they overlay the map itself.  It looks bad.  This fix adds `respond-to-legacy-support` to the `poi_list.sass` and places the description below the map.

* To check this PR open a hotel page in IE8 and check that the POIs descriptions are below the map.