### PR TITLE
Fix the 'story behind the picture' feature in hero banners

### DIFF
--- a/app/assets/stylesheets/components/_banner.sass
+++ b/app/assets/stylesheets/components/_banner.sass
@@ -95,13 +95,22 @@
   line-height: 50px
 
 .hero-banner__image-story
-  +z-layer(top)
-  bottom: -55px
+  +z-layer(middle)
   position: absolute
-  transition: bottom 0.5s ease
+  top: 100%
+  transition: top 0.5s ease
   width: 100%
+  .supports-transform .is-active &
+    top: 50%
   .is-active &
-    bottom: 40%
+    top: 35px
+    .copy--h4
+      top: -15px
+  .copy--h4
+    position: absolute
+    top: -48px
+    transition: top 0.5s ease
+    width: 100%
 
 .hero-banner__image-story__cover
   +alpha-background($darkgray, 0.75)
@@ -145,6 +154,8 @@
 
 .hero-banner__image-story__content
   text-align: center
+  .supports-transform .is-active &
+    transform: translateY(-50%)
   .copy--body
     +font-size(18)
     color: white

--- a/app/assets/stylesheets/components/_banner.sass
+++ b/app/assets/stylesheets/components/_banner.sass
@@ -97,20 +97,13 @@
 .hero-banner__image-story
   +z-layer(middle)
   position: absolute
-  top: 100%
+  top: 90%
   transition: top 0.5s ease
   width: 100%
   .supports-transform .is-active &
     top: 50%
   .is-active &
     top: 35px
-    .copy--h4
-      top: -15px
-  .copy--h4
-    position: absolute
-    top: -48px
-    transition: top 0.5s ease
-    width: 100%
 
 .hero-banner__image-story__cover
   +alpha-background($darkgray, 0.75)

--- a/app/data/styleguide/herobanner_stubs.yml
+++ b/app/data/styleguide/herobanner_stubs.yml
@@ -5,7 +5,7 @@
 
 -
   :image_url: "http://assets.staticlp.com/slothstronaut.jpg"
-  :image_caption: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. A distinctio aperiam cumque aliquam tempore nam accusamus et voluptatibus libero reiciendis! Suscipit facere nihil obcaecati quia expedita, deleniti, sapiente odio sed!"
+  :image_caption: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. A distinctio aperiam cumque aliquam tempore nam accusamus et voluptatibus libero reiciendis! Suscipit facere nihil obcaecati quia expedita, deleniti, sapiente odio sed! Lorem ipsum dolor sit amet, consectetur adipisicing elit. A distinctio aperiam cumque aliquam tempore nam accusamus et voluptatibus libero reiciendis! Suscipit facere nihil obcaecati quia expedita, deleniti, sapiente odio sed! Lorem ipsum dolor sit amet, consectetur adipisicing elit. A distinctio aperiam cumque aliquam tempore nam accusamus et voluptatibus libero reiciendis! Suscipit facere nihil obcaecati quia expedita, deleniti, sapiente odio sed! Lorem ipsum dolor sit amet, consectetur adipisicing elit. A distinctio aperiam cumque aliquam tempore nam accusamus et voluptatibus libero reiciendis! Suscipit facere nihil obcaecati quia expedita, deleniti, sapiente odio sed!"
   :image_info:
     :attribution: "Slothy"
     :attribution_url: "/styleguide/404"


### PR DESCRIPTION
Before:
![1423494582](https://cloud.githubusercontent.com/assets/708296/6108792/d0bb2dd8-b06d-11e4-8ba3-3b9298fa4b1a.png)

After:
![story-behind](https://cloud.githubusercontent.com/assets/708296/6108752/84653c80-b06d-11e4-90eb-d32a8756e654.gif)