### PR TITLE
Adding shim for deparam plugin

### DIFF
--- a/app/views/layouts/partials/inline_js/_require_js_config.html.haml
+++ b/app/views/layouts/partials/inline_js/_require_js_config.html.haml
@@ -20,6 +20,7 @@
       pickerLegacy: "pickadate/lib/legacy"
     },
     shim: {
+      "jquery-bbq-deparam/jquery-deparam": [ "jquery" ],
       "xdr": [ "jquery" ],
       "dfp": [ "jquery"]
     },


### PR DESCRIPTION
## Description

Adding a shim in require so ensure that jQuery is loaded before the deparam plugin loads.  Production was encountering a race condition issue where the deparam plugin was being loaded before jQuery itself was done being loaded.  This caused cascading errors to happen and all kinds of ugliness on the pages handled by Waldorf.

## Verification
1. Check out branch and point Waldorf to local rizzo
1. Visit `http://localhost:8080/austria` and verify that ads load and no JavaScript errors are reported in the console. Specifically the `jQuery not defined` error that was happening in production.
