### PR TITLE
remove duplicate :date attribute from form inputs

### DIFF
--- a/app/views/components/forms/_radio_buttons_field.html.haml
+++ b/app/views/components/forms/_radio_buttons_field.html.haml
@@ -1,7 +1,7 @@
 = render :layout => 'components/forms/partials/field', :locals => { id: properties[:id], label: properties[:label], extra_class: "field--radio #{properties[:extra_class]}", tooltip: properties[:tooltip] } do
   - properties[:options].each do |option|
     %span.input__container.js-input{ class: properties[:error] ? 'field__input--error' : nil }
-      %input.input--radio{ type: "radio", name: option[:name], id: option[:id], checked: option[:checked] ? 'checked' : nil, data: option[:data], value: option[:value], data: properties[:rules] ? { rules: properties[:rules] } : {} }
+      %input.input--radio{ type: "radio", name: option[:name], id: option[:id], checked: option[:checked] ? 'checked' : nil, value: option[:value], data: option[:data].to_h.merge(rules: properties[:rules]) }
       %label.js-field-label{ for: option[:id] }<
         = option[:label]
   = render :partial => 'components/forms/partials/tooltip', :locals => { tooltip: properties[:tooltip] }

--- a/app/views/components/forms/_text_area.html.haml
+++ b/app/views/components/forms/_text_area.html.haml
@@ -1,4 +1,4 @@
 = find_and_preserve do
-  %textarea.input.input--text-area{ id: properties[:id], name: properties[:name], placeholder: properties[:placeholder], rows: properties[:rows], cols: properties[:cols], data: properties[:data], maxlength: properties[:maxlength], data: properties[:rules] ? { rules: properties[:rules] } : {}, readonly: properties[:readonly].present? }
+  %textarea.input.input--text-area{ id: properties[:id], name: properties[:name], placeholder: properties[:placeholder], rows: properties[:rows], cols: properties[:cols], maxlength: properties[:maxlength], data: properties[:data].to_h.merge(rules: properties[:rules]), readonly: properties[:readonly].present? }
     = properties[:value] || ""
 = render :partial => 'components/forms/partials/tooltip', :locals => { tooltip: properties[:tooltip] }


### PR DESCRIPTION
fixes errors:
```
/app/views/components/forms/_radio_buttons_field.html.haml:4: warning: duplicated key at line 4 ignored: :data
/app/views/components/forms/_text_area.html.haml:2: warning: duplicated key at line 2 ignored: :data
```

these _warnings_ started showing in Rails 4.2.

I'm not sure anyone uses these features or where we could test the behaviour is correct? tests are passing...

@remybach can you have a look? :pray: 