### PR TITLE
Fix issue with events  not working

### DIFF
--- a/app/assets/javascripts/lib/components/poi_map.js
+++ b/app/assets/javascripts/lib/components/poi_map.js
@@ -56,7 +56,7 @@ define([
   POIMap.prototype._init = function() {
     if (window.innerWidth < 980)  return;
 
-    this.$placeholder.on({
+    this.$container.on({
       "click.poi": this._mouseClickHandler.bind(this),
       "mousemove.preload": this._mouseMoveHandler.bind(this),
       "mouseleave.preload": this._mouseLeaveHandler.bind(this)


### PR DESCRIPTION
The container div has been places absolutely on the placeholder. An `mv--inline` class has been put on the container as of January 25th, this has caused events not fire on the placeholder.

https://github.com/lonelyplanet/rizzo/blame/5c329b314761290f7b61288e02e084e795c1023b/app/assets/stylesheets/core/utilities/_responsive.sass#L114

Simply changing where the events are bound to the container seems to resolve the issue.