### PR TITLE
Ds add snapto on range slider

### DIFF
--- a/app/views/components/forms/_range_slider.html.haml
+++ b/app/views/components/forms/_range_slider.html.haml
@@ -2,7 +2,7 @@
   %h4.copy--h4
     = properties[:title]
 
-  .js-range-slider{data: {range: "#{properties[:min][:extreme]},#{properties[:max][:extreme]}", current: "#{properties[:min][:value]},#{properties[:max][:value]}", targets: "#{properties[:min][:name]},#{properties[:max][:name]}", cap_level: "#{properties[:cap_level] ? properties[:cap_level] : false}", unit: raw(properties[:unit]), unit_position: properties[:unit_position]}}
+  .js-range-slider{data: {range: "#{properties[:min][:extreme]},#{properties[:max][:extreme]}", current: "#{properties[:min][:value]},#{properties[:max][:value]}", targets: "#{properties[:min][:name]},#{properties[:max][:name]}", cap_level: "#{properties[:cap_level] ? properties[:cap_level] : false}", unit: raw(properties[:unit]), unit_position: properties[:unit_position], snap_date_at: "#{properties[:snap_date_at] ? properties[:snap_date_at] : false}"}}
 
   .range-slider__labels.clearfix.js-range-labels<
     %span.split--left.js-range-min #{raw(properties[:unit])}#{properties[:min][:value]}

--- a/spec/javascripts/lib/components/range_slider_spec.js
+++ b/spec/javascripts/lib/components/range_slider_spec.js
@@ -30,8 +30,8 @@ define(['public/assets/javascripts/lib/components/range_slider.js'], function(Ra
         config = rangeSlider._getConfig(input);
         expect(config.handles).toEqual(2);
         expect(config.connect).toEqual(true);
-        expect(config.range).toEqual(["0", "100"]);
-        return expect(config.start).toEqual(["40", "60"]);
+        expect(config.range).toEqual({ min: [0, 1], max: [100, 1]});
+        return expect(config.start).toEqual([40, 60]);
       });
     });
     describe("A capped slider", function() {
@@ -49,8 +49,8 @@ define(['public/assets/javascripts/lib/components/range_slider.js'], function(Ra
         config = rangeSlider._getConfig(input);
         expect(config.handles).toEqual(2);
         expect(config.connect).toEqual(true);
-        expect(config.range).toEqual(["0", "90"]);
-        return expect(config.start).toEqual(["40", "60"]);
+        expect(config.range).toEqual({ min: [0, 1], max: [90, 1]});
+        return expect(config.start).toEqual([40, 60]);
       });
       return it('reduces the current amount if above the cap', function() {
         var config, input;
@@ -63,8 +63,28 @@ define(['public/assets/javascripts/lib/components/range_slider.js'], function(Ra
         config = rangeSlider._getConfig(input);
         expect(config.handles).toEqual(2);
         expect(config.connect).toEqual(true);
-        expect(config.range).toEqual(["0", "90"]);
-        return expect(config.start).toEqual(["40", "90"]);
+        expect(config.range).toEqual({ min: [0, 1], max: [90, 1] });
+        return expect(config.start).toEqual([40, 90]);
+      });
+    });
+    describe("A snap_date_at slider", function() {
+      beforeEach(function() {
+        return window.rangeSlider = new RangeSlider();
+      });
+      it("creates a breakpoint in granularity", function () {
+        var config, input;
+        input = {
+          range: "1,720",
+          current: "1,10",
+          targets: "foo,bar",
+          capLevel: "199",
+          snapDateAt: "48"
+        };
+        config = rangeSlider._getConfig(input);
+        expect(config.handles).toEqual(2);
+        expect(config.connect).toEqual(true);
+        expect(config.range).toEqual({ min: [1, 1], '24%': [48, 24], max: [199, 1]});
+        return expect(config.start).toEqual([1, 10]);
       });
     });
     return describe("Updating the units", function() {

--- a/vendor/assets/javascripts/nouislider/jquery.nouislider.js
+++ b/vendor/assets/javascripts/nouislider/jquery.nouislider.js
@@ -1,25 +1,7 @@
-/*! $.noUiSlider
- @version 5.0.0
- @author Leon Gersen https://twitter.com/LeonGersen
- @license WTFPL http://www.wtfpl.net/about/
- @documentation http://refreshless.com/nouislider/
-*/
-
-// ==ClosureCompiler==
-// @externs_url http://refreshless.com/externs/jquery-1.8.js
-// @compilation_level ADVANCED_OPTIMIZATIONS
-// @warning_level VERBOSE
-// ==/ClosureCompiler==
-
-/*jshint laxcomma: true */
-/*jshint smarttabs: true */
-/*jshint sub: true */
+/*! noUiSlider - 7.0.10 - 2014-12-27 14:50:46 */
 
 /*jslint browser: true */
-/*jslint continue: true */
-/*jslint plusplus: true */
 /*jslint white: true */
-/*jslint sub: true */
 
 // -----------------------------------------------------------------------------
 // LP Change
@@ -32,1398 +14,1436 @@
 
 define([ "jquery" ], function($){
 
-	'use strict';
-
-	if ( $['zepto'] && !$.fn.removeData ) {
-		throw new ReferenceError('Zepto is loaded without the data module.');
-	}
-
-	$.fn['noUiSlider'] = function( options, rebuild ){
-
-		var
-		// Cache the document and body selectors;
-		 doc = $(document)
-		,body = $('body')
-
-		// Namespace for binding and unbinding slider events;
-		,namespace = '.nui'
-
-		// Copy of the current value function;
-		,$VAL = $.fn.val
-
-		// Re-usable list of classes;
-		,clsList = [
-		/*  0 */  'noUi-base'
-		/*  1 */ ,'noUi-origin'
-		/*  2 */ ,'noUi-handle'
-		/*  3 */ ,'noUi-input'
-		/*  4 */ ,'noUi-active'
-		/*  5 */ ,'noUi-state-tap'
-		/*  6 */ ,'noUi-target'
-		/*  7 */ ,'-lower'
-		/*  8 */ ,'-upper'
-		/*  9 */ ,'noUi-connect'
-		/* 10 */ ,'noUi-horizontal'
-		/* 11 */ ,'noUi-vertical'
-		/* 12 */ ,'noUi-background'
-		/* 13 */ ,'noUi-stacking'
-		/* 14 */ ,'noUi-block'
-		/* 15 */ ,'noUi-state-blocked'
-		/* 16 */ ,'noUi-ltr'
-		/* 17 */ ,'noUi-rtl'
-		/* 18 */ ,'noUi-dragable'
-		/* 19 */ ,'noUi-extended'
-		/* 20 */ ,'noUi-state-drag'
-		]
-
-		// Determine the events to bind. IE11 implements pointerEvents without
-		// a prefix, which breaks compatibility with the IE10 implementation.
-		,actions = window.navigator['pointerEnabled'] ? {
-			 start: 'pointerdown'
-			,move: 'pointermove'
-			,end: 'pointerup'
-		} : window.navigator['msPointerEnabled'] ? {
-			 start: 'MSPointerDown'
-			,move: 'MSPointerMove'
-			,end: 'MSPointerUp'
-		} : {
-			 start: 'mousedown touchstart'
-			,move: 'mousemove touchmove'
-			,end: 'mouseup touchend'
-		};
-
-
-// Percentage calculation
-
-	// (percentage) How many percent is this value of this range?
-		function fromPercentage ( range, value ) {
-			return (value * 100) / ( range[1] - range[0] );
-		}
-
-	// (percentage) Where is this value on this range?
-		function toPercentage ( range, value ) {
-			return fromPercentage( range, range[0] < 0 ?
-				value + Math.abs(range[0]) :
-					value - range[0] );
-		}
-
-	// (value) How much is this percentage on this range?
-		function isPercentage ( range, value ) {
-			return ((value * ( range[1] - range[0] )) / 100) + range[0];
-		}
-
-
-// Type tests
-
-	// Test in an object is an instance of jQuery or Zepto.
-		function isInstance ( a ) {
-			return a instanceof $ || ( $['zepto'] && $['zepto']['isZ'](a) );
-		}
-
-	// Checks whether a value is numerical.
-		function isNumeric ( a ) {
-			return !isNaN( parseFloat( a ) ) && isFinite( a );
-		}
-
-
-// General helper functions
-
-	// Test an array of objects, and calls them if they are a function.
-		function call ( functions, scope ) {
-
-			// Allow the passing of an unwrapped function.
-			// Leaves other code a more comprehensible.
-			if( !$.isArray( functions ) ){
-				functions = [ functions ];
-			}
-
-			$.each( functions, function(){
-				if (typeof this === 'function') {
-					this.call(scope);
-				}
-			});
-		}
-
-	// Returns a proxy to set a target using the public value method.
-		function setN ( target, number ) {
-
-			return function(){
-
-				// Determine the correct position to set,
-				// leave the other one unchanged.
-				var val = [null, null];
-				val[ number ] = $(this).val();
-
-				// Trigger the 'set' callback
-				target.val(val, true);
-			};
-		}
-
-	// Round a value to the closest 'to'.
-		function closest ( value, to ){
-			return Math.round(value / to) * to;
-		}
-
-	// Format output value to specified standards.
-		function format ( value, options ) {
-
-			// Round the value to the resolution that was set
-			// with the serialization options.
-			value = value.toFixed( options['decimals'] );
-
-			// Rounding away decimals might cause a value of -0
-			// when using very small ranges. Remove those cases.
-			if ( parseFloat(value) === 0 ) {
-				value = value.replace('-0', '0');
-			}
-
-			// Apply the proper decimal mark to the value.
-			return value.replace( '.', options['serialization']['mark'] );
-		}
-
-	// Determine the handle closest to an event.
-		function closestHandle ( handles, location, style ) {
-
-			if ( handles.length === 1 ) {
-				return handles[0];
-			}
-
-			var total = handles[0].offset()[style] +
-						handles[1].offset()[style];
-
-			return handles[ location < total / 2 ? 0 : 1 ];
-		}
-
-	// Round away small numbers in floating point implementation.
-		function digits ( value, round ) {
-			return parseFloat(value.toFixed(round));
-		}
-
-// Event abstraction
-
-	// Provide a clean event with standardized offset values.
-		function fixEvent ( e ) {
-
-			// Prevent scrolling and panning on touch events, while
-			// attempting to slide. The tap event also depends on this.
-			e.preventDefault();
-
-			// Filter the event to register the type, which can be
-			// touch, mouse or pointer. Offset changes need to be
-			// made on an event specific basis.
-			var  touch = e.type.indexOf('touch') === 0
-				,mouse = e.type.indexOf('mouse') === 0
-				,pointer = e.type.indexOf('pointer') === 0
-				,x,y, event = e;
-
-			// IE10 implemented pointer events with a prefix;
-			if ( e.type.indexOf('MSPointer') === 0 ) {
-				pointer = true;
-			}
-
-			// Get the originalEvent, if the event has been wrapped
-			// by jQuery. Zepto doesn't wrap the event.
-			if ( e.originalEvent ) {
-				e = e.originalEvent;
-			}
-
-			if ( touch ) {
-				// noUiSlider supports one movement at a time,
-				// so we can select the first 'changedTouch'.
-				x = e.changedTouches[0].pageX;
-				y = e.changedTouches[0].pageY;
-			}
-			if ( mouse || pointer ) {
-
-				// Polyfill the pageXOffset and pageYOffset
-				// variables for IE7 and IE8;
-				if( !pointer && window.pageXOffset === undefined ){
-					window.pageXOffset = document.documentElement.scrollLeft;
-					window.pageYOffset = document.documentElement.scrollTop;
-				}
-
-				x = e.clientX + window.pageXOffset;
-				y = e.clientY + window.pageYOffset;
-			}
-
-			return $.extend( event, {
-				 'pointX': x
-				,'pointY': y
-				,cursor: mouse
-			});
-		}
-
-	// Handler for attaching events trough a proxy
-		function attach ( events, element, callback, pass ) {
-
-			var target = pass.target;
-
-			// Add the noUiSlider namespace to all events.
-			events = events.replace( /\s/g, namespace + ' ' ) + namespace;
-
-			// Bind a closure on the target.
-			return element.on( events, function( e ){
-
-				// jQuery and Zepto handle unset attributes differently.
-				var disabled = target.attr('disabled');
-					disabled = !( disabled === undefined || disabled === null );
-
-				// Test if there is anything that should prevent an event
-				// from being handled, such as a disabled state or an active
-				// 'tap' transition.
-				if( target.hasClass('noUi-state-tap') || disabled ) {
-					return false;
-				}
-
-				// Call the event handler with three arguments:
-				// - The event;
-				// - An object with data for the event;
-				// - The slider options;
-				// Having the slider options as a function parameter prevents
-				// getting it in every function, which muddies things up.
-				callback (
-					 fixEvent( e )
-					,pass
-					,target.data('base').data('options')
-				);
-			});
-		}
-
-
-// Serialization and value storage
-
-	// Store a value on all serialization targets, or get the current value.
-		function serialize ( a ) {
-
-			/*jshint validthis: true */
-
-			// Re-scope target for availability within .each;
-			var target = this.target;
-
-			// Get the value for this handle
-			if ( a === undefined ) {
-				return this.element.data('value');
-			}
-
-			// Write the value to all serialization objects
-			// or store a new value on the handle
-			if ( a === true ) {
-				a = this.element.data('value');
-			} else {
-				this.element.data('value', a);
-			}
-
-			// Prevent a serialization call if the value wasn't initialized.
-			if ( a === undefined ) {
-				return;
-			}
-
-			// If the provided element was a function,
-			// call it with the slider as scope. Otherwise,
-			// simply call the function on the object.
-			$.each( this.elements, function() {
-				if ( typeof this === 'function' ) {
-					this.call(target, a);
-				} else {
-					this[0][this[1]](a);
-				}
-			});
-		}
-
-	// Map serialization to [ element, method ]. Attach events where required.
-		function storeElement ( handle, item, number ) {
-
-			// Add a change event to the supplied jQuery objects,
-			// which triggers the value-setting function on the target.
-			if ( isInstance( item ) ) {
-
-				var elements = [], target = handle.data('target');
-
-				// Link the field to the other handle if the
-				// slider is inverted.
-				if ( handle.data('options').direction ) {
-					number = number ? 0 : 1;
-				}
-
-				// Loop all items so the change event is properly bound,
-				// and the items can individually be added to the array.
-				item.each(function(){
-
-					// Bind the change event.
-					$(this).on('change' + namespace, setN( target, number ));
-
-					// Store the element with the proper handler.
-					elements.push([ $(this), 'val' ]);
-				});
-
-				return elements;
-			}
-
-			// Append a new input to the noUiSlider base.
-			// Prevent the change event from flowing upward.
-			if ( typeof item === 'string' ) {
-
-				item = [ $('<input type="hidden" name="'+ item +'">')
-					.appendTo(handle)
-					.addClass(clsList[3])
-					.change(function ( e ) {
-						e.stopPropagation();
-					}), 'val'];
-			}
-
-			return [item];
-		}
-
-	// Access point and abstraction for serialization.
-		function store ( handle, i, serialization ) {
-
-			var elements = [];
-
-			// Loops all items in the provided serialization setting,
-			// add the proper events to them or create new input fields,
-			// and add them as data to the handle so they can be kept
-			// in sync with the slider value.
-			$.each( serialization['to'][i], function( index ){
-				elements = elements.concat(
-					storeElement( handle, serialization['to'][i][index], i )
-				);
-			});
-
-			return {
-				 element: handle
-				,elements: elements
-				,target: handle.data('target')
-				,'val': serialize
-			};
-		}
-
-
-// Handle placement
-
-	// Fire callback on unsuccessful handle movement.
-		function block ( base, stateless ) {
-
-			var target = base.data('target');
-
-			if ( !target.hasClass(clsList[14]) ){
-
-				// The visual effects should not always be applied.
-				if ( !stateless ) {
-					target.addClass(clsList[15]);
-					setTimeout(function(){
-						target.removeClass(clsList[15]);
-					}, 450);
-				}
-
-				target.addClass(clsList[14]);
-				call( base.data('options').block, target );
-			}
-		}
-
-	// Change inline style and apply proper classes.
-		function placeHandle ( handle, to ) {
-
-			var settings = handle.data('options');
-
-			to = digits(to, 7);
-
-			// If the slider can move, remove the class
-			// indicating the block state.
-			handle.data('target').removeClass(clsList[14]);
-
-			// Set handle to new location
-			handle.css( settings['style'], to + '%' ).data('pct', to);
-
-			// Force proper handle stacking
-			if ( handle.is(':first-child') ) {
-				handle.toggleClass(clsList[13], to > 50 );
-			}
-
-			if ( settings['direction'] ) {
-				to = 100 - to;
-			}
-
-			// Write the value to the serialization object.
-			handle.data('store').val(
-				format ( isPercentage( settings['range'], to ), settings )
-			);
-		}
-
-	// Test suggested values and apply margin, step.
-		function setHandle ( handle, to ) {
-
-			var base = handle.data('base'), settings = base.data('options'),
-				handles = base.data('handles'), lower = 0, upper = 100;
-
-			// Catch invalid user input
-			if ( !isNumeric( to ) ){
-				return false;
-			}
-
-			// Handle the step option.
-			if ( settings['step'] ){
-				to = closest( to, settings['step'] );
-			}
-
-			if ( handles.length > 1 ){
-				if ( handle[0] !== handles[0][0] ) {
-					lower = digits(handles[0].data('pct')+settings['margin'],7);
-				} else {
-					upper = digits(handles[1].data('pct')-settings['margin'],7);
-				}
-			}
-
-			// Limit position to boundaries. When the handles aren't set yet,
-			// they return -1 as a percentage value.
-			to = Math.min( Math.max( to, lower ), upper < 0 ? 100 : upper );
-
-			// Stop handling this call if the handle can't move past another.
-			// Return an array containing the hit limit, so the caller can
-			// provide feedback. ( block callback ).
-			if ( to === handle.data('pct') ) {
-				return [!lower ? false : lower, upper === 100 ? false : upper];
-			}
-
-			placeHandle ( handle, to );
-			return true;
-		}
-
-	// Handles movement by tapping
-		function jump ( base, handle, to, callbacks ) {
-
-			// Flag the slider as it is now in a transitional state.
-			// Transition takes 300 ms, so re-enable the slider afterwards.
-			base.addClass(clsList[5]);
-			setTimeout(function(){
-				base.removeClass(clsList[5]);
-			}, 300);
-
-			// Move the handle to the new position.
-			setHandle( handle, to );
-
-			// Trigger the 'slide' and 'set' callbacks,
-			// pass the target so that it is 'this'.
-			call( callbacks, base.data('target') );
-
-			base.data('target').change();
-		}
-
-
-// Event handlers
-
-	// Handle movement on document for handle and range drag.
-		function move ( event, Dt, Op ) {
-
-			// Map event movement to a slider percentage.
-			var handles = Dt.handles, limits,
-				proposal = event[ Dt.point ] - Dt.start[ Dt.point ];
-
-			proposal = ( proposal * 100 ) / Dt.size;
-
-			if ( handles.length === 1 ) {
-
-				// Run handle placement, receive true for success or an
-				// array with potential limits.
-				limits = setHandle( handles[0], Dt.positions[0] + proposal );
-
-				if ( limits !== true ) {
-
-					if ( $.inArray ( handles[0].data('pct'), limits ) >= 0 ){
-						block ( Dt.base, !Op['margin'] );
-					}
-					return;
-				}
-
-			} else {
-
-				// Dragging the range could be implemented by forcing the
-				// 'move' event on both handles, but this solution proved
-				// lagging on slower devices, resulting in range errors. The
-				// slightly ugly solution below is considerably faster, and
-				// it can't move the handle out of sync. Bypass the standard
-				// setting method, as other checks are needed.
-
-				var l1, u1, l2, u2;
-
-				// Round the proposal to the step setting.
-				if ( Op['step'] ) {
-					proposal = closest( proposal, Op['step'] );
-				}
-
-				// Determine the new position, store it twice. Once for
-				// limiting, once for checking whether placement should occur.
-				l1 = l2 = Dt.positions[0] + proposal;
-				u1 = u2 = Dt.positions[1] + proposal;
-
-				// Round the values within a sensible range.
-				if ( l1 < 0 ) {
-					u1 += -1 * l1;
-					l1 = 0;
-				} else if ( u1 > 100 ) {
-					l1 -= ( u1 - 100 );
-					u1 = 100;
-				}
-
-				// Don't perform placement if no handles are to be changed.
-				// Check if the lowest value is set to zero.
-				if ( l2 < 0 && !l1 && !handles[0].data('pct') ) {
-					return;
-				}
-				// The highest value is limited to 100%.
-				if ( u1 === 100 && u2 > 100 && handles[1].data('pct') === 100 ){
-					return;
-				}
-
-				placeHandle ( handles[0], l1 );
-				placeHandle ( handles[1], u1 );
-			}
-
-			// Trigger the 'slide' event, if the handle was moved.
-			call( Op['slide'], Dt.target );
-		}
-
-	// Unbind move events on document, call callbacks.
-		function end ( event, Dt, Op ) {
-
-			// The handle is no longer active, so remove the class.
-			if ( Dt.handles.length === 1 ) {
-				Dt.handles[0].data('grab').removeClass(clsList[4]);
-			}
-
-			// Remove cursor styles and text-selection events bound to the body.
-			if ( event.cursor ) {
-				body.css('cursor', '').off( namespace );
-			}
-
-			// Unbind the move and end events, which are added on 'start'.
-			doc.off( namespace );
-
-			// Trigger the change event.
-			Dt.target.removeClass( clsList[14] +' '+ clsList[20]).change();
-
-			// Trigger the 'end' callback.
-			call( Op['set'], Dt.target );
-		}
-
-	// Bind move events on document.
-		function start ( event, Dt, Op ) {
-
-			// Mark the handle as 'active' so it can be styled.
-			if( Dt.handles.length === 1 ) {
-				Dt.handles[0].data('grab').addClass(clsList[4]);
-			}
-
-			// A drag should never propagate up to the 'tap' event.
-			event.stopPropagation();
-
-			// Attach the move event.
-			attach ( actions.move, doc, move, {
-				 start: event
-				,base: Dt.base
-				,target: Dt.target
-				,handles: Dt.handles
-				,positions: [ Dt.handles[0].data('pct')
-					   ,Dt.handles[ Dt.handles.length - 1 ].data('pct') ]
-				,point: Op['orientation'] ? 'pointY' : 'pointX'
-				,size: Op['orientation'] ? Dt.base.height() : Dt.base.width()
-			});
-
-			// Unbind all movement when the drag ends.
-			attach ( actions.end, doc, end, {
-				 target: Dt.target
-				,handles: Dt.handles
-			});
-
-			// Text selection isn't an issue on touch devices,
-			// so adding additional callbacks isn't required.
-			if ( event.cursor ) {
-
-				// Prevent the 'I' cursor and extend the range-drag cursor.
-				body.css('cursor', $(event.target).css('cursor'));
-
-				// Mark the target with a dragging state.
-				if ( Dt.handles.length > 1 ) {
-					Dt.target.addClass(clsList[20]);
-				}
-
-				// Prevent text selection when dragging the handles.
-				body.on('selectstart' + namespace, function( ){
-					return false;
-				});
-			}
-		}
-
-	// Move closest handle to tapped location.
-		function tap ( event, Dt, Op ) {
-
-			var base = Dt.base, handle, to, point, size;
-
-			// The tap event shouldn't propagate up to trigger 'edge'.
-			event.stopPropagation();
-
-			// Determine the direction of the slider.
-			if ( Op['orientation'] ) {
-				point = event['pointY'];
-				size = base.height();
-			} else {
-				point = event['pointX'];
-				size = base.width();
-			}
-
-			// Find the closest handle and calculate the tapped point.
-			handle = closestHandle( base.data('handles'), point, Op['style'] );
-			to = (( point - base.offset()[ Op['style'] ] ) * 100 ) / size;
-
-			// The set handle to the new position.
-			jump( base, handle, to, [ Op['slide'], Op['set'] ]);
-		}
-
-	// Move handle to edges when target gets tapped.
-		function edge ( event, Dt, Op ) {
-
-			var handles = Dt.base.data('handles'), to, i;
-
-			i = Op['orientation'] ? event['pointY'] : event['pointX'];
-			i = i < Dt.base.offset()[Op['style']];
-
-			to = i ? 0 : 100;
-			i = i ? 0 : handles.length - 1;
-
-			jump ( Dt.base, handles[i], to, [ Op['slide'], Op['set'] ]);
-		}
-
-// API
-
-	// Validate and standardize input.
-		function test ( input, sliders ){
-
-	/*	Every input option is tested and parsed. This'll prevent
-		endless validation in internal methods. These tests are
-		structured with an item for every option available. An
-		option can be marked as required by setting the 'r' flag.
-		The testing function is provided with three arguments:
-			- The provided value for the option;
-			- A reference to the options object;
-			- The name for the option;
-
-		The testing function returns false when an error is detected,
-		or true when everything is OK. It can also modify the option
-		object, to make sure all values can be correctly looped elsewhere. */
-
-			function values ( a ) {
-
-				if ( a.length !== 2 ){
-					return false;
-				}
-
-				// Convert the array to floats
-				a = [ parseFloat(a[0]), parseFloat(a[1]) ];
-
-				// Test if all values are numerical
-				if( !isNumeric(a[0]) || !isNumeric(a[1]) ){
-					return false;
-				}
-
-				// The lowest value must really be the lowest value.
-				if( a[1] < a[0] ){
-					return false;
-				}
-
-				return a;
-			}
-
-			var serialization = {
-				 resolution: function(q,o){
-
-					// Parse the syntactic sugar that is the serialization
-					// resolution option to a usable integer.
-					// Checking for a string '1', since the resolution needs
-					// to be cast to a string to split in on the period.
-					switch( q ){
-						case 1:
-						case 0.1:
-						case 0.01:
-						case 0.001:
-						case 0.0001:
-						case 0.00001:
-							q = q.toString().split('.');
-							o['decimals'] = q[0] === '1' ? 0 : q[1].length;
-							break;
-						case undefined:
-							o['decimals'] = 2;
-							break;
-						default:
-							return false;
-					}
-
-					return true;
-				}
-				,mark: function(q,o,w){
-
-					if ( !q ) {
-						o[w]['mark'] = '.';
-						return true;
-					}
-
-					switch( q ){
-						case '.':
-						case ',':
-							return true;
-						default:
-							return false;
-					}
-				}
-				,to: function(q,o,w){
-
-					// Checks whether a variable is a candidate to be a
-					// valid serialization target.
-					function ser(r){
-						return isInstance ( r ) ||
-							typeof r === 'string' ||
-							typeof r === 'function' ||
-							r === false ||
-							( isInstance ( r[0] ) &&
-							  typeof r[0][r[1]] === 'function' );
-					}
-
-					// Flatten the serialization array into a reliable
-					// set of elements, which can be tested and looped.
-					function filter ( value ) {
-
-						var items = [[],[]];
-
-						// If a single value is provided it can be pushed
-						// immediately.
-						if ( ser(value) ) {
-							items[0].push(value);
-						} else {
-
-							// Otherwise, determine whether this is an
-							// array of single elements or sets.
-							$.each(value, function(i, val) {
-
-								// Don't handle an overflow of elements.
-								if( i > 1 ){
-									return;
-								}
-
-								// Decide if this is a group or not
-								if( ser(val) ){
-									items[i].push(val);
-								} else {
-									items[i] = items[i].concat(val);
-								}
-							});
-						}
-
-						return items;
-					}
-
-					if ( !q ) {
-						o[w]['to'] = [[],[]];
-					} else {
-
-						var i, j;
-
-						// Flatten the serialization array
-						q = filter ( q );
-
-						// Reverse the API for RTL sliders.
-						if ( o['direction'] && q[1].length ) {
-							q.reverse();
-						}
-
-						// Test all elements in the flattened array.
-						for ( i = 0; i < o['handles']; i++ ) {
-							for ( j = 0; j < q[i].length; j++ ) {
-
-								// Return false on invalid input
-								if( !ser(q[i][j]) ){
-									return false;
-								}
-
-								// Remove 'false' elements, since those
-								// won't be handled anyway.
-								if( !q[i][j] ){
-									q[i].splice(j, 1);
-								}
-							}
-						}
-
-						// Write the new values back
-						o[w]['to'] = q;
-					}
-
-					return true;
-				}
-			}, tests = {
-				/*	Handles.
-				 *	Has default, can be 1 or 2.
-				 */
-				 'handles': {
-					 'r': true
-					,'t': function(q){
-						q = parseInt(q, 10);
-						return ( q === 1 || q === 2 );
-					}
-				}
-				/*	Range.
-				 *	Must be an array of two numerical floats,
-				 *	which can't be identical.
-				 */
-				,'range': {
-					 'r': true
-					,'t': function(q,o,w){
-
-						o[w] = values(q);
-
-						// The values can't be identical.
-						return o[w] && o[w][0] !== o[w][1];
-					}
-				 }
-				/*	Start.
-				 *	Must be an array of two numerical floats when handles = 2;
-				 *	Uses 'range' test.
-				 *	When handles = 1, a single float is also allowed.
-				 */
-				,'start': {
-					 'r': true
-					,'t': function(q,o,w){
-						if( o['handles'] === 1 ){
-							if( $.isArray(q) ){
-								q = q[0];
-							}
-							q = parseFloat(q);
-							o.start = [q];
-							return isNumeric(q);
-						}
-
-						o[w] = values(q);
-						return !!o[w];
-					}
-				}
-				/*	Connect.
-				 *	Must be true or false when handles = 2;
-				 *	Can use 'lower' and 'upper' when handles = 1.
-				 */
-				,'connect': {
-					 'r': true
-					,'t': function(q,o,w){
-
-						if ( q === 'lower' ) {
-							o[w] = 1;
-						} else if ( q === 'upper' ) {
-							o[w] = 2;
-						} else if ( q === true ) {
-							o[w] = 3;
-						} else if ( q === false ) {
-							o[w] = 0;
-						} else {
-							return false;
-						}
-
-						return true;
-					}
-				}
-				/*	Connect.
-				 *	Will default to horizontal, not required.
-				 */
-				,'orientation': {
-					 't': function(q,o,w){
-						switch (q){
-							case 'horizontal':
-								o[w] = 0;
-								break;
-							case 'vertical':
-								o[w] = 1;
-								break;
-							default: return false;
-						}
-						return true;
-					}
-				}
-				/*	Margin.
-				 *	Must be a float, has a default value.
-				 */
-				,'margin': {
-					 'r': true
-					,'t': function(q,o,w){
-						q = parseFloat(q);
-						o[w] = fromPercentage(o['range'], q);
-						return isNumeric(q);
-					}
-				}
-				/*	Direction.
-				 *	Required, can be 'ltr' or 'rtl'.
-				 */
-				,'direction': {
-					 'r': true
-					,'t': function(q,o,w){
-
-						switch ( q ) {
-							case 'ltr': o[w] = 0;
-								break;
-							case 'rtl': o[w] = 1;
-								// Invert connection for RTL sliders;
-								o['connect'] = [0,2,1,3][o['connect']];
-								break;
-							default:
-								return false;
-						}
-
-						return true;
-					}
-				}
-				/*	Behaviour.
-				 *	Required, defines responses to tapping and
-				 *	dragging elements.
-				 */
-				,'behaviour': {
-					 'r': true
-					,'t': function(q,o,w){
-
-						o[w] = {
-							 'tap': q !== (q = q.replace('tap', ''))
-							,'extend': q !== (q = q.replace('extend', ''))
-							,'drag': q !== (q = q.replace('drag', ''))
-							,'fixed': q !== (q = q.replace('fixed', ''))
-						};
-
-						return !q.replace('none','').replace(/\-/g,'');
-					}
-				}
-				/*	Serialization.
-				 *	Required, but has default. Must be an array
-				 *	when using two handles, can be a single value when using
-				 *	one handle. 'mark' can be period (.) or comma (,).
-				 */
-				,'serialization': {
-					 'r': true
-					,'t': function(q,o,w){
-
-						return serialization.to( q['to'], o, w ) &&
-							   serialization.resolution( q['resolution'], o ) &&
-							   serialization.mark( q['mark'], o, w );
-					}
-				}
-				/*	Slide.
-				 *	Not required. Must be a function.
-				 */
-				,'slide': {
-					 't': function(q){
-						return $.isFunction(q);
-					}
-				}
-				/*	Set.
-				 *	Not required. Must be a function.
-				 *	Tested using the 'slide' test.
-				 */
-				,'set': {
-					 't': function(q){
-						return $.isFunction(q);
-					}
-				}
-				/*	Block.
-				 *	Not required. Must be a function.
-				 *	Tested using the 'slide' test.
-				 */
-				,'block': {
-					 't': function(q){
-						return $.isFunction(q);
-					}
-				}
-				/*	Step.
-				 *	Not required.
-				 */
-				,'step': {
-					 't': function(q,o,w){
-						q = parseFloat(q);
-						o[w] = fromPercentage ( o['range'], q );
-						return isNumeric(q);
-					}
-				}
-			};
-
-			$.each( tests, function( name, test ){
-
-				/*jslint devel: true */
-
-				var value = input[name], isSet = value !== undefined;
-
-				// If the value is required but not set, fail.
-				if( ( test['r'] && !isSet ) ||
-				// If the test returns false, fail.
-					( isSet && !test['t']( value, input, name ) ) ){
-
-					// For debugging purposes it might be very useful to know
-					// what option caused the trouble. Since throwing an error
-					// will prevent further script execution, log the error
-					// first. Test for console, as it might not be available.
-					if( console && console.log && console.group ){
-						console.group( 'Invalid noUiSlider initialisation:' );
-						console.log( 'Option:\t', name );
-						console.log( 'Value:\t', value );
-						console.log( 'Slider(s):\t', sliders );
-						console.groupEnd();
-					}
-
-					throw new RangeError('noUiSlider');
-				}
-			});
-		}
-
-	// Parse options, add classes, attach events, create HTML.
-		function create ( options ) {
-
-			/*jshint validthis: true */
-
-			// Store the original set of options on all targets,
-			// so they can be re-used and re-tested later.
-			// Make sure to break the relation with the options,
-			// which will be changed by the 'test' function.
-			this.data('options', $.extend(true, {}, options));
-
-			// Set defaults where applicable;
-			options = $.extend({
-				 'handles': 2
-				,'margin': 0
-				,'connect': false
-				,'direction': 'ltr'
-				,'behaviour': 'tap'
-				,'orientation': 'horizontal'
-			}, options);
-
-			// Make sure the test for serialization runs.
-			options['serialization'] = options['serialization'] || {};
-
-			// Run all options through a testing mechanism to ensure correct
-			// input. The test function will throw errors, so there is
-			// no need to capture the result of this call. It should be noted
-			// that options might get modified to be handled properly. E.g.
-			// wrapping integers in arrays.
-			test( options, this );
-
-			// Pre-define the styles.
-			options['style'] = options['orientation'] ? 'top' : 'left';
-
-			return this.each(function(){
-
-				var target = $(this), i, dragable, handles = [], handle,
-					base = $('<div/>').appendTo(target);
-
-				// Throw an error if the slider was already initialized.
-				if ( target.data('base') ) {
-					throw new Error('Slider was already initialized.');
-				}
-
-				// Apply classes and data to the target.
-				target.data('base', base).addClass([
-					clsList[6]
-				   ,clsList[16 + options['direction']]
-				   ,clsList[10 + options['orientation']] ].join(' '));
-
-				for (i = 0; i < options['handles']; i++ ) {
-
-					handle = $('<div><div/></div>').appendTo(base);
-
-					// Add all default and option-specific classes to the
-					// origins and handles.
-					handle.addClass( clsList[1] );
-
-					handle.children().addClass([
-						clsList[2]
-					   ,clsList[2] + clsList[ 7 + options['direction'] +
-						( options['direction'] ? -1 * i : i ) ]].join(' ') );
-
-					// Make sure every handle has access to all variables.
-					handle.data({
-						 'base': base
-						,'target': target
-						,'options': options
-						,'grab': handle.children()
-						,'pct': -1
-					}).attr('data-style', options['style']);
-
-					// Every handle has a storage point, which takes care
-					// of triggering the proper serialization callbacks.
-					handle.data({
-						'store': store(handle, i, options['serialization'])
-					});
-
-					// Store handles on the base
-					handles.push(handle);
-				}
-
-				// Apply the required connection classes to the elements
-				// that need them. Some classes are made up for several
-				// segments listed in the class list, to allow easy
-				// renaming and provide a minor compression benefit.
-				switch ( options['connect'] ) {
-					case 1:	target.addClass( clsList[9] );
-							handles[0].addClass( clsList[12] );
-							break;
-					case 3: handles[1].addClass( clsList[12] );
-							/* falls through */
-					case 2: handles[0].addClass( clsList[9] );
-							/* falls through */
-					case 0: target.addClass(clsList[12]);
-							break;
-				}
-
-				// Merge base classes with default,
-				// and store relevant data on the base element.
-				base.addClass( clsList[0] ).data({
-					 'target': target
-					,'options': options
-					,'handles': handles
-				});
-
-				// Use the public value method to set the start values.
-				target.val( options['start'] );
-
-				// Attach the standard drag event to the handles.
-				if ( !options['behaviour']['fixed'] ) {
-					for ( i = 0; i < handles.length; i++ ) {
-
-						// These events are only bound to the visual handle
-						// element, not the 'real' origin element.
-						attach ( actions.start, handles[i].children(), start, {
-							 base: base
-							,target: target
-							,handles: [ handles[i] ]
-						});
-					}
-				}
-
-				// Attach the tap event to the slider base.
-				if ( options['behaviour']['tap'] ) {
-					attach ( actions.start, base, tap, {
-						 base: base
-						,target: target
-					});
-				}
-
-				// Extend tapping behaviour to target
-				if ( options['behaviour']['extend'] ) {
-
-					target.addClass( clsList[19] );
-
-					if ( options['behaviour']['tap'] ) {
-						attach ( actions.start, target, edge, {
-							 base: base
-							,target: target
-						});
-					}
-				}
-
-				// Make the range dragable.
-				if ( options['behaviour']['drag'] ){
-
-					dragable = base.find('.'+clsList[9]).addClass(clsList[18]);
-
-					// When the range is fixed, the entire range can
-					// be dragged by the handles. The handle in the first
-					// origin will propagate the start event upward,
-					// but it needs to be bound manually on the other.
-					if ( options['behaviour']['fixed'] ) {
-						dragable = dragable
-							.add( base.children().not(dragable).data('grab') );
-					}
-
-					attach ( actions.start, dragable, start, {
-						 base: base
-						,target: target
-						,handles: handles
-					});
-				}
-			});
-		}
-
-	// Return value for the slider, relative to 'range'.
-		function getValue ( ) {
-
-			/*jshint validthis: true */
-
-			var base = $(this).data('base'), answer = [];
-
-			// Loop the handles, and get the value from the input
-			// for every handle on its' own.
-			$.each( base.data('handles'), function(){
-				answer.push( $(this).data('store').val() );
-			});
-
-			// If the slider has just one handle, return a single value.
-			// Otherwise, return an array, which is in reverse order
-			// if the slider is used RTL.
-			if ( answer.length === 1 ) {
-				return answer[0];
-			}
-
-			if ( base.data('options').direction ) {
-				return answer.reverse();
-			}
-
-			return answer;
-		}
-
-	// Set value for the slider, relative to 'range'.
-		function setValue ( args, set ) {
-
-			/*jshint validthis: true */
-
-			// If the value is to be set to a number, which is valid
-			// when using a one-handle slider, wrap it in an array.
-			if( !$.isArray(args) ){
-				args = [args];
-			}
-
-			// Setting is handled properly for each slider in the data set.
-			return this.each(function(){
-
-				var b = $(this).data('base'), to, i,
-					handles = Array.prototype.slice.call(b.data('handles'),0),
-					settings = b.data('options');
-
-				// If there are multiple handles to be set run the setting
-				// mechanism twice for the first handle, to make sure it
-				// can be bounced of the second one properly.
-				if ( handles.length > 1) {
-					handles[2] = handles[0];
-				}
-
-				// The RTL settings is implemented by reversing the front-end,
-				// internal mechanisms are the same.
-				if ( settings['direction'] ) {
-					args.reverse();
-				}
-
-				for ( i = 0; i < handles.length; i++ ){
-
-					// Calculate a new position for the handle.
-					to = args[ i%2 ];
-
-					// The set request might want to ignore this handle.
-					// Test for 'undefined' too, as a two-handle slider
-					// can still be set with an integer.
-					if( to === null || to === undefined ) {
-						continue;
-					}
-
-					// Add support for the comma (,) as a decimal symbol.
-					// Replace it by a period so it is handled properly by
-					// parseFloat. Omitting this would result in a removal
-					// of decimals. This way, the developer can also
-					// input a comma separated string.
-					if( $.type(to) === 'string' ) {
-						to = to.replace(',', '.');
-					}
-
-					// Calculate the new handle position
-					to = toPercentage( settings['range'], parseFloat( to ) );
-
-					// Invert the value if this is an right-to-left slider.
-					if ( settings['direction'] ) {
-						to = 100 - to;
-					}
-
-					// If the value of the input doesn't match the slider,
-					// reset it. Sometimes the input is changed to a value the
-					// slider has rejected. This can occur when using 'select'
-					// or 'input[type="number"]' elements. In this case, set
-					// the value back to the input.
-					if ( setHandle( handles[i], to ) !== true ){
-						handles[i].data('store').val( true );
-					}
-
-					// Optionally trigger the 'set' event.
-					if( set === true ) {
-						call( settings['set'], $(this) );
-					}
-				}
-			});
-		}
-
-	// Unbind all attached events, remove classed and HTML.
-		function destroy ( target ) {
-
-			// Start the list of elements to be unbound with the target.
-			var elements = [[target,'']];
-
-			// Get the fields bound to both handles.
-			$.each(target.data('base').data('handles'), function(){
-				elements = elements.concat( $(this).data('store').elements );
-			});
-
-			// Remove all events added by noUiSlider.
-			$.each(elements, function(){
-				if( this.length > 1 ){
-					this[0].off( namespace );
-				}
-			});
-
-			// Remove all classes from the target.
-			target.removeClass(clsList.join(' '));
-
-			// Empty the target and remove all data.
-			target.empty().removeData('base options');
-		}
-
-	// Merge options with current initialization, destroy slider
-	// and reinitialize.
-		function build ( options ) {
-
-			/*jshint validthis: true */
-
-			return this.each(function(){
-
-				// When uninitialised, jQuery will return '',
-				// Zepto returns undefined. Both are falsy.
-				var values = $(this).val() || false,
-					current = $(this).data('options'),
-				// Extend the current setup with the new options.
-					setup = $.extend( {}, current, options );
-
-				// If there was a slider initialised, remove it first.
-				if ( values !== false ) {
-					destroy( $(this) );
-				}
-
-				// Make the destroy method publicly accessible.
-				if( !options ) {
-					return;
-				}
-
-				// Create a new slider
-				$(this)['noUiSlider']( setup );
-
-				// Set the slider values back. If the start options changed,
-				// it gets precedence.
-				if ( values !== false && setup.start === current.start ) {
-					$(this).val( values );
-				}
-			});
-		}
-
-	// Overwrite the native jQuery value function
-	// with a simple handler. noUiSlider will use the internal
-	// value method, anything else will use the standard method.
-		$.fn.val = function(){
-
-			// If the function is called without arguments,
-			// act as a 'getter'. Call the getValue function
-			// in the same scope as this call.
-			if ( this.hasClass( clsList[6] ) ){
-				return arguments.length ?
-					setValue.apply( this, arguments ) :
-					getValue.apply( this );
-			}
-
-			// If this isn't noUiSlider, continue with jQuery's
-			// original method.
-			return $VAL.apply( this, arguments );
-		};
-
-		return ( rebuild ? build : create ).call( this, options );
-	};
+'use strict';
+
+
+  // Removes duplicates from an array.
+  function unique(array) {
+    return $.grep(array, function(el, index) {
+      return index === $.inArray(el, array);
+    });
+  }
+
+  // Round a value to the closest 'to'.
+  function closest ( value, to ) {
+    return Math.round(value / to) * to;
+  }
+
+  // Checks whether a value is numerical.
+  function isNumeric ( a ) {
+    return typeof a === 'number' && !isNaN( a ) && isFinite( a );
+  }
+
+  // Rounds a number to 7 supported decimals.
+  function accurateNumber( number ) {
+    var p = Math.pow(10, 7);
+    return Number((Math.round(number*p)/p).toFixed(7));
+  }
+
+  // Sets a class and removes it after [duration] ms.
+  function addClassFor ( element, className, duration ) {
+    element.addClass(className);
+    setTimeout(function(){
+      element.removeClass(className);
+    }, duration);
+  }
+
+  // Limits a value to 0 - 100
+  function limit ( a ) {
+    return Math.max(Math.min(a, 100), 0);
+  }
+
+  // Wraps a variable as an array, if it isn't one yet.
+  function asArray ( a ) {
+    return $.isArray(a) ? a : [a];
+  }
+
+  // Counts decimals
+  function countDecimals ( numStr ) {
+    var pieces = numStr.split(".");
+    return pieces.length > 1 ? pieces[1].length : 0;
+  }
+
+
+  var
+  // Cache the document selector;
+  /** @const */
+  doc = $(document),
+  // Make a backup of the original jQuery/Zepto .val() method.
+  /** @const */
+  $val = $.fn.val,
+  // Namespace for binding and unbinding slider events;
+  /** @const */
+  namespace = '.nui',
+  // Determine the events to bind. IE11 implements pointerEvents without
+  // a prefix, which breaks compatibility with the IE10 implementation.
+  /** @const */
+  actions = window.navigator.pointerEnabled ? {
+    start: 'pointerdown',
+    move: 'pointermove',
+    end: 'pointerup'
+  } : window.navigator.msPointerEnabled ? {
+    start: 'MSPointerDown',
+    move: 'MSPointerMove',
+    end: 'MSPointerUp'
+  } : {
+    start: 'mousedown touchstart',
+    move: 'mousemove touchmove',
+    end: 'mouseup touchend'
+  },
+  // Re-usable list of classes;
+  /** @const */
+  Classes = [
+/*  0 */  'noUi-target'
+/*  1 */ ,'noUi-base'
+/*  2 */ ,'noUi-origin'
+/*  3 */ ,'noUi-handle'
+/*  4 */ ,'noUi-horizontal'
+/*  5 */ ,'noUi-vertical'
+/*  6 */ ,'noUi-background'
+/*  7 */ ,'noUi-connect'
+/*  8 */ ,'noUi-ltr'
+/*  9 */ ,'noUi-rtl'
+/* 10 */ ,'noUi-dragable'
+/* 11 */ ,''
+/* 12 */ ,'noUi-state-drag'
+/* 13 */ ,''
+/* 14 */ ,'noUi-state-tap'
+/* 15 */ ,'noUi-active'
+/* 16 */ ,''
+/* 17 */ ,'noUi-stacking'
+  ];
+
+
+// Value calculation
+
+  // Determine the size of a sub-range in relation to a full range.
+  function subRangeRatio ( pa, pb ) {
+    return (100 / (pb - pa));
+  }
+
+  // (percentage) How many percent is this value of this range?
+  function fromPercentage ( range, value ) {
+    return (value * 100) / ( range[1] - range[0] );
+  }
+
+  // (percentage) Where is this value on this range?
+  function toPercentage ( range, value ) {
+    return fromPercentage( range, range[0] < 0 ?
+      value + Math.abs(range[0]) :
+        value - range[0] );
+  }
+
+  // (value) How much is this percentage on this range?
+  function isPercentage ( range, value ) {
+    return ((value * ( range[1] - range[0] )) / 100) + range[0];
+  }
+
+
+// Range conversion
+
+  function getJ ( value, arr ) {
+
+    var j = 1;
+
+    while ( value >= arr[j] ){
+      j += 1;
+    }
+
+    return j;
+  }
+
+  // (percentage) Input a value, find where, on a scale of 0-100, it applies.
+  function toStepping ( xVal, xPct, value ) {
+
+    if ( value >= xVal.slice(-1)[0] ){
+      return 100;
+    }
+
+    var j = getJ( value, xVal ), va, vb, pa, pb;
+
+    va = xVal[j-1];
+    vb = xVal[j];
+    pa = xPct[j-1];
+    pb = xPct[j];
+
+    return pa + (toPercentage([va, vb], value) / subRangeRatio (pa, pb));
+  }
+
+  // (value) Input a percentage, find where it is on the specified range.
+  function fromStepping ( xVal, xPct, value ) {
+
+    // There is no range group that fits 100
+    if ( value >= 100 ){
+      return xVal.slice(-1)[0];
+    }
+
+    var j = getJ( value, xPct ), va, vb, pa, pb;
+
+    va = xVal[j-1];
+    vb = xVal[j];
+    pa = xPct[j-1];
+    pb = xPct[j];
+
+    return isPercentage([va, vb], (value - pa) * subRangeRatio (pa, pb));
+  }
+
+  // (percentage) Get the step that applies at a certain value.
+  function getStep ( xPct, xSteps, snap, value ) {
+
+    if ( value === 100 ) {
+      return value;
+    }
+
+    var j = getJ( value, xPct ), a, b;
+
+    // If 'snap' is set, steps are used as fixed points on the slider.
+    if ( snap ) {
+
+      a = xPct[j-1];
+      b = xPct[j];
+
+      // Find the closest position, a or b.
+      if ((value - a) > ((b-a)/2)){
+        return b;
+      }
+
+      return a;
+    }
+
+    if ( !xSteps[j-1] ){
+      return value;
+    }
+
+    return xPct[j-1] + closest(
+      value - xPct[j-1],
+      xSteps[j-1]
+    );
+  }
+
+
+// Entry parsing
+
+  function handleEntryPoint ( index, value, that ) {
+
+    var percentage;
+
+    // Wrap numerical input in an array.
+    if ( typeof value === "number" ) {
+      value = [value];
+    }
+
+    // Reject any invalid input, by testing whether value is an array.
+    if ( Object.prototype.toString.call( value ) !== '[object Array]' ){
+      throw new Error("noUiSlider: 'range' contains invalid value.");
+    }
+
+    // Covert min/max syntax to 0 and 100.
+    if ( index === 'min' ) {
+      percentage = 0;
+    } else if ( index === 'max' ) {
+      percentage = 100;
+    } else {
+      percentage = parseFloat( index );
+    }
+
+    // Check for correct input.
+    if ( !isNumeric( percentage ) || !isNumeric( value[0] ) ) {
+      throw new Error("noUiSlider: 'range' value isn't numeric.");
+    }
+
+    // Store values.
+    that.xPct.push( percentage );
+    that.xVal.push( value[0] );
+
+    // NaN will evaluate to false too, but to keep
+    // logging clear, set step explicitly. Make sure
+    // not to override the 'step' setting with false.
+    if ( !percentage ) {
+      if ( !isNaN( value[1] ) ) {
+        that.xSteps[0] = value[1];
+      }
+    } else {
+      that.xSteps.push( isNaN(value[1]) ? false : value[1] );
+    }
+  }
+
+  function handleStepPoint ( i, n, that ) {
+
+    // Ignore 'false' stepping.
+    if ( !n ) {
+      return true;
+    }
+
+    // Factor to range ratio
+    that.xSteps[i] = fromPercentage([
+       that.xVal[i]
+      ,that.xVal[i+1]
+    ], n) / subRangeRatio (
+      that.xPct[i],
+      that.xPct[i+1] );
+  }
+
+
+// Interface
+
+  // The interface to Spectrum handles all direction-based
+  // conversions, so the above values are unaware.
+
+  function Spectrum ( entry, snap, direction, singleStep ) {
+
+    this.xPct = [];
+    this.xVal = [];
+    this.xSteps = [ singleStep || false ];
+    this.xNumSteps = [ false ];
+
+    this.snap = snap;
+    this.direction = direction;
+
+    var index, ordered = [ /* [0, 'min'], [1, '50%'], [2, 'max'] */ ];
+
+    // Map the object keys to an array.
+    for ( index in entry ) {
+      if ( entry.hasOwnProperty(index) ) {
+        ordered.push([entry[index], index]);
+      }
+    }
+
+    // Sort all entries by value (numeric sort).
+    ordered.sort(function(a, b) { return a[0] - b[0]; });
+
+    // Convert all entries to subranges.
+    for ( index = 0; index < ordered.length; index++ ) {
+      handleEntryPoint(ordered[index][1], ordered[index][0], this);
+    }
+
+    // Store the actual step values.
+    // xSteps is sorted in the same order as xPct and xVal.
+    this.xNumSteps = this.xSteps.slice(0);
+
+    // Convert all numeric steps to the percentage of the subrange they represent.
+    for ( index = 0; index < this.xNumSteps.length; index++ ) {
+      handleStepPoint(index, this.xNumSteps[index], this);
+    }
+  }
+
+  Spectrum.prototype.getMargin = function ( value ) {
+    return this.xPct.length === 2 ? fromPercentage(this.xVal, value) : false;
+  };
+
+  Spectrum.prototype.toStepping = function ( value ) {
+
+    value = toStepping( this.xVal, this.xPct, value );
+
+    // Invert the value if this is a right-to-left slider.
+    if ( this.direction ) {
+      value = 100 - value;
+    }
+
+    return value;
+  };
+
+  Spectrum.prototype.fromStepping = function ( value ) {
+
+    // Invert the value if this is a right-to-left slider.
+    if ( this.direction ) {
+      value = 100 - value;
+    }
+
+    return accurateNumber(fromStepping( this.xVal, this.xPct, value ));
+  };
+
+  Spectrum.prototype.getStep = function ( value ) {
+
+    // Find the proper step for rtl sliders by search in inverse direction.
+    // Fixes issue #262.
+    if ( this.direction ) {
+      value = 100 - value;
+    }
+
+    value = getStep(this.xPct, this.xSteps, this.snap, value );
+
+    if ( this.direction ) {
+      value = 100 - value;
+    }
+
+    return value;
+  };
+
+  Spectrum.prototype.getApplicableStep = function ( value ) {
+
+    // If the value is 100%, return the negative step twice.
+    var j = getJ(value, this.xPct), offset = value === 100 ? 2 : 1;
+    return [this.xNumSteps[j-2], this.xVal[j-offset], this.xNumSteps[j-offset]];
+  };
+
+  // Outside testing
+  Spectrum.prototype.convert = function ( value ) {
+    return this.getStep(this.toStepping(value));
+  };
+
+/*  Every input option is tested and parsed. This'll prevent
+  endless validation in internal methods. These tests are
+  structured with an item for every option available. An
+  option can be marked as required by setting the 'r' flag.
+  The testing function is provided with three arguments:
+    - The provided value for the option;
+    - A reference to the options object;
+    - The name for the option;
+
+  The testing function returns false when an error is detected,
+  or true when everything is OK. It can also modify the option
+  object, to make sure all values can be correctly looped elsewhere. */
+
+  /** @const */
+  var defaultFormatter = { 'to': function( value ){
+    return value.toFixed(2);
+  }, 'from': Number };
+
+  function testStep ( parsed, entry ) {
+
+    if ( !isNumeric( entry ) ) {
+      throw new Error("noUiSlider: 'step' is not numeric.");
+    }
+
+    // The step option can still be used to set stepping
+    // for linear sliders. Overwritten if set in 'range'.
+    parsed.singleStep = entry;
+  }
+
+  function testRange ( parsed, entry ) {
+
+    // Filter incorrect input.
+    if ( typeof entry !== 'object' || $.isArray(entry) ) {
+      throw new Error("noUiSlider: 'range' is not an object.");
+    }
+
+    // Catch missing start or end.
+    if ( entry.min === undefined || entry.max === undefined ) {
+      throw new Error("noUiSlider: Missing 'min' or 'max' in 'range'.");
+    }
+
+    parsed.spectrum = new Spectrum(entry, parsed.snap, parsed.dir, parsed.singleStep);
+  }
+
+  function testStart ( parsed, entry ) {
+
+    entry = asArray(entry);
+
+    // Validate input. Values aren't tested, as the public .val method
+    // will always provide a valid location.
+    if ( !$.isArray( entry ) || !entry.length || entry.length > 2 ) {
+      throw new Error("noUiSlider: 'start' option is incorrect.");
+    }
+
+    // Store the number of handles.
+    parsed.handles = entry.length;
+
+    // When the slider is initialized, the .val method will
+    // be called with the start options.
+    parsed.start = entry;
+  }
+
+  function testSnap ( parsed, entry ) {
+
+    // Enforce 100% stepping within subranges.
+    parsed.snap = entry;
+
+    if ( typeof entry !== 'boolean' ){
+      throw new Error("noUiSlider: 'snap' option must be a boolean.");
+    }
+  }
+
+  function testAnimate ( parsed, entry ) {
+
+    // Enforce 100% stepping within subranges.
+    parsed.animate = entry;
+
+    if ( typeof entry !== 'boolean' ){
+      throw new Error("noUiSlider: 'animate' option must be a boolean.");
+    }
+  }
+
+  function testConnect ( parsed, entry ) {
+
+    if ( entry === 'lower' && parsed.handles === 1 ) {
+      parsed.connect = 1;
+    } else if ( entry === 'upper' && parsed.handles === 1 ) {
+      parsed.connect = 2;
+    } else if ( entry === true && parsed.handles === 2 ) {
+      parsed.connect = 3;
+    } else if ( entry === false ) {
+      parsed.connect = 0;
+    } else {
+      throw new Error("noUiSlider: 'connect' option doesn't match handle count.");
+    }
+  }
+
+  function testOrientation ( parsed, entry ) {
+
+    // Set orientation to an a numerical value for easy
+    // array selection.
+    switch ( entry ){
+      case 'horizontal':
+      parsed.ort = 0;
+      break;
+      case 'vertical':
+      parsed.ort = 1;
+      break;
+      default:
+      throw new Error("noUiSlider: 'orientation' option is invalid.");
+    }
+  }
+
+  function testMargin ( parsed, entry ) {
+
+    if ( !isNumeric(entry) ){
+      throw new Error("noUiSlider: 'margin' option must be numeric.");
+    }
+
+    parsed.margin = parsed.spectrum.getMargin(entry);
+
+    if ( !parsed.margin ) {
+      throw new Error("noUiSlider: 'margin' option is only supported on linear sliders.");
+    }
+  }
+
+  function testLimit ( parsed, entry ) {
+
+    if ( !isNumeric(entry) ){
+      throw new Error("noUiSlider: 'limit' option must be numeric.");
+    }
+
+    parsed.limit = parsed.spectrum.getMargin(entry);
+
+    if ( !parsed.limit ) {
+      throw new Error("noUiSlider: 'limit' option is only supported on linear sliders.");
+    }
+  }
+
+  function testDirection ( parsed, entry ) {
+
+    // Set direction as a numerical value for easy parsing.
+    // Invert connection for RTL sliders, so that the proper
+    // handles get the connect/background classes.
+    switch ( entry ) {
+      case 'ltr':
+      parsed.dir = 0;
+      break;
+      case 'rtl':
+      parsed.dir = 1;
+      parsed.connect = [0,2,1,3][parsed.connect];
+      break;
+      default:
+      throw new Error("noUiSlider: 'direction' option was not recognized.");
+    }
+  }
+
+  function testBehaviour ( parsed, entry ) {
+
+    // Make sure the input is a string.
+    if ( typeof entry !== 'string' ) {
+      throw new Error("noUiSlider: 'behaviour' must be a string containing options.");
+    }
+
+    // Check if the string contains any keywords.
+    // None are required.
+    var tap = entry.indexOf('tap') >= 0,
+      drag = entry.indexOf('drag') >= 0,
+      fixed = entry.indexOf('fixed') >= 0,
+      snap = entry.indexOf('snap') >= 0;
+
+    parsed.events = {
+      tap: tap || snap,
+      drag: drag,
+      fixed: fixed,
+      snap: snap
+    };
+  }
+
+  function testFormat ( parsed, entry ) {
+
+    parsed.format = entry;
+
+    // Any object with a to and from method is supported.
+    if ( typeof entry.to === 'function' && typeof entry.from === 'function' ) {
+      return true;
+    }
+
+    throw new Error( "noUiSlider: 'format' requires 'to' and 'from' methods.");
+  }
+
+  // Test all developer settings and parse to assumption-safe values.
+  function testOptions ( options ) {
+
+    var parsed = {
+      margin: 0,
+      limit: 0,
+      animate: true,
+      format: defaultFormatter
+    }, tests;
+
+    // Tests are executed in the order they are presented here.
+    tests = {
+      'step': { r: false, t: testStep },
+      'start': { r: true, t: testStart },
+      'connect': { r: true, t: testConnect },
+      'direction': { r: true, t: testDirection },
+      'snap': { r: false, t: testSnap },
+      'animate': { r: false, t: testAnimate },
+      'range': { r: true, t: testRange },
+      'orientation': { r: false, t: testOrientation },
+      'margin': { r: false, t: testMargin },
+      'limit': { r: false, t: testLimit },
+      'behaviour': { r: true, t: testBehaviour },
+      'format': { r: false, t: testFormat }
+    };
+
+    // Set defaults where applicable.
+    options = $.extend({
+      'connect': false,
+      'direction': 'ltr',
+      'behaviour': 'tap',
+      'orientation': 'horizontal'
+    }, options);
+
+    // Run all options through a testing mechanism to ensure correct
+    // input. It should be noted that options might get modified to
+    // be handled properly. E.g. wrapping integers in arrays.
+    $.each( tests, function( name, test ){
+
+      // If the option isn't set, but it is required, throw an error.
+      if ( options[name] === undefined ) {
+
+        if ( test.r ) {
+          throw new Error("noUiSlider: '" + name + "' is required.");
+        }
+
+        return true;
+      }
+
+      test.t( parsed, options[name] );
+    });
+
+    // Pre-define the styles.
+    parsed.style = parsed.ort ? 'top' : 'left';
+
+    return parsed;
+  }
+
+// Class handling
+
+  // Delimit proposed values for handle positions.
+  function getPositions ( a, b, delimit ) {
+
+    // Add movement to current position.
+    var c = a + b[0], d = a + b[1];
+
+    // Only alter the other position on drag,
+    // not on standard sliding.
+    if ( delimit ) {
+      if ( c < 0 ) {
+        d += Math.abs(c);
+      }
+      if ( d > 100 ) {
+        c -= ( d - 100 );
+      }
+
+      // Limit values to 0 and 100.
+      return [limit(c), limit(d)];
+    }
+
+    return [c,d];
+  }
+
+
+// Event handling
+
+  // Provide a clean event with standardized offset values.
+  function fixEvent ( e ) {
+
+    // Prevent scrolling and panning on touch events, while
+    // attempting to slide. The tap event also depends on this.
+    e.preventDefault();
+
+    // Filter the event to register the type, which can be
+    // touch, mouse or pointer. Offset changes need to be
+    // made on an event specific basis.
+    var  touch = e.type.indexOf('touch') === 0
+      ,mouse = e.type.indexOf('mouse') === 0
+      ,pointer = e.type.indexOf('pointer') === 0
+      ,x,y, event = e;
+
+    // IE10 implemented pointer events with a prefix;
+    if ( e.type.indexOf('MSPointer') === 0 ) {
+      pointer = true;
+    }
+
+    // Get the originalEvent, if the event has been wrapped
+    // by jQuery. Zepto doesn't wrap the event.
+    if ( e.originalEvent ) {
+      e = e.originalEvent;
+    }
+
+    if ( touch ) {
+      // noUiSlider supports one movement at a time,
+      // so we can select the first 'changedTouch'.
+      x = e.changedTouches[0].pageX;
+      y = e.changedTouches[0].pageY;
+    }
+
+    if ( mouse || pointer ) {
+
+      // Polyfill the pageXOffset and pageYOffset
+      // variables for IE7 and IE8;
+      if( !pointer && window.pageXOffset === undefined ){
+        window.pageXOffset = document.documentElement.scrollLeft;
+        window.pageYOffset = document.documentElement.scrollTop;
+      }
+
+      x = e.clientX + window.pageXOffset;
+      y = e.clientY + window.pageYOffset;
+    }
+
+    event.points = [x, y];
+    event.cursor = mouse;
+
+    return event;
+  }
+
+
+// DOM additions
+
+  // Append a handle to the base.
+  function addHandle ( direction, index ) {
+
+    var handle = $('<div><div/></div>').addClass( Classes[2] ),
+      additions = [ '-lower', '-upper' ];
+
+    if ( direction ) {
+      additions.reverse();
+    }
+
+    handle.children().addClass(
+      Classes[3] + " " + Classes[3]+additions[index]
+    );
+
+    return handle;
+  }
+
+  // Add the proper connection classes.
+  function addConnection ( connect, target, handles ) {
+
+    // Apply the required connection classes to the elements
+    // that need them. Some classes are made up for several
+    // segments listed in the class list, to allow easy
+    // renaming and provide a minor compression benefit.
+    switch ( connect ) {
+      case 1: target.addClass( Classes[7] );
+          handles[0].addClass( Classes[6] );
+          break;
+      case 3: handles[1].addClass( Classes[6] );
+          /* falls through */
+      case 2: handles[0].addClass( Classes[7] );
+          /* falls through */
+      case 0: target.addClass(Classes[6]);
+          break;
+    }
+  }
+
+  // Add handles to the slider base.
+  function addHandles ( nrHandles, direction, base ) {
+
+    var index, handles = [];
+
+    // Append handles.
+    for ( index = 0; index < nrHandles; index += 1 ) {
+
+      // Keep a list of all added handles.
+      handles.push( addHandle( direction, index ).appendTo(base) );
+    }
+
+    return handles;
+  }
+
+  // Initialize a single slider.
+  function addSlider ( direction, orientation, target ) {
+
+    // Apply classes and data to the target.
+    target.addClass([
+      Classes[0],
+      Classes[8 + direction],
+      Classes[4 + orientation]
+    ].join(' '));
+
+    return $('<div/>').appendTo(target).addClass( Classes[1] );
+  }
+
+function closure ( target, options, originalOptions ){
+
+// Internal variables
+
+  // All variables local to 'closure' are marked $.
+  var $Target = $(target),
+    $Locations = [-1, -1],
+    $Base,
+    $Handles,
+    $Spectrum = options.spectrum,
+    $Values = [],
+  // libLink. For rtl sliders, 'lower' and 'upper' should not be inverted
+  // for one-handle sliders, so trim 'upper' it that case.
+    triggerPos = ['lower', 'upper'].slice(0, options.handles);
+
+  // Invert the libLink connection for rtl sliders.
+  if ( options.dir ) {
+    triggerPos.reverse();
+  }
+
+// Helpers
+
+  // Shorthand for base dimensions.
+  function baseSize ( ) {
+    return $Base[['width', 'height'][options.ort]]();
+  }
+
+  // External event handling
+  function fireEvents ( events ) {
+
+    // Use the external api to get the values.
+    // Wrap the values in an array, as .trigger takes
+    // only one additional argument.
+    var index, values = [ $Target.val() ];
+
+    for ( index = 0; index < events.length; index += 1 ){
+      $Target.trigger(events[index], values);
+    }
+  }
+
+  // Returns the input array, respecting the slider direction configuration.
+  function inSliderOrder ( values ) {
+
+    // If only one handle is used, return a single value.
+    if ( values.length === 1 ){
+      return values[0];
+    }
+
+    if ( options.dir ) {
+      return values.reverse();
+    }
+
+    return values;
+  }
+
+// libLink integration
+
+  // Create a new function which calls .val on input change.
+  function createChangeHandler ( trigger ) {
+    return function ( ignore, value ){
+      // Determine which array position to 'null' based on 'trigger'.
+      $Target.val( [ trigger ? null : value, trigger ? value : null ], true );
+    };
+  }
+
+  // Called by libLink when it wants a set of links updated.
+  function linkUpdate ( flag ) {
+
+    var trigger = $.inArray(flag, triggerPos);
+
+    // The API might not have been set yet.
+    if ( $Target[0].linkAPI && $Target[0].linkAPI[flag] ) {
+      $Target[0].linkAPI[flag].change(
+        $Values[trigger],
+        $Handles[trigger].children(),
+        $Target
+      );
+    }
+  }
+
+  // Called by libLink to append an element to the slider.
+  function linkConfirm ( flag, element ) {
+
+    // Find the trigger for the passed flag.
+    var trigger = $.inArray(flag, triggerPos);
+
+    // If set, append the element to the handle it belongs to.
+    if ( element ) {
+      element.appendTo( $Handles[trigger].children() );
+    }
+
+    // The public API is reversed for rtl sliders, so the changeHandler
+    // should not be aware of the inverted trigger positions.
+    // On rtl slider with one handle, 'lower' should be used.
+    if ( options.dir && options.handles > 1 ) {
+      trigger = trigger === 1 ? 0 : 1;
+    }
+
+    return createChangeHandler( trigger );
+  }
+
+  // Place elements back on the slider.
+  function reAppendLink ( ) {
+
+    var i, flag;
+
+    // The API keeps a list of elements: we can re-append them on rebuild.
+    for ( i = 0; i < triggerPos.length; i += 1 ) {
+      if ( this.linkAPI && this.linkAPI[(flag = triggerPos[i])] ) {
+        this.linkAPI[flag].reconfirm(flag);
+      }
+    }
+  }
+
+  target.LinkUpdate = linkUpdate;
+  target.LinkConfirm = linkConfirm;
+  target.LinkDefaultFormatter = options.format;
+  target.LinkDefaultFlag = 'lower';
+
+  target.reappend = reAppendLink;
+
+
+  // Handler for attaching events trough a proxy.
+  function attach ( events, element, callback, data ) {
+
+    // This function can be used to 'filter' events to the slider.
+
+    // Add the noUiSlider namespace to all events.
+    events = events.replace( /\s/g, namespace + ' ' ) + namespace;
+
+    // Bind a closure on the target.
+    return element.on( events, function( e ){
+
+      // jQuery and Zepto (1) handle unset attributes differently,
+      // but always falsy; #208
+      if ( !!$Target.attr('disabled') ) {
+        return false;
+      }
+
+      // Stop if an active 'tap' transition is taking place.
+      if ( $Target.hasClass( Classes[14] ) ) {
+        return false;
+      }
+
+      e = fixEvent(e);
+      e.calcPoint = e.points[ options.ort ];
+
+      // Call the event handler with the event [ and additional data ].
+      callback ( e, data );
+    });
+  }
+
+  // Handle movement on document for handle and range drag.
+  function move ( event, data ) {
+
+    var handles = data.handles || $Handles, positions, state = false,
+      proposal = ((event.calcPoint - data.start) * 100) / baseSize(),
+      h = handles[0][0] !== $Handles[0][0] ? 1 : 0;
+
+    // Calculate relative positions for the handles.
+    positions = getPositions( proposal, data.positions, handles.length > 1);
+
+    state = setHandle ( handles[0], positions[h], handles.length === 1 );
+
+    if ( handles.length > 1 ) {
+      state = setHandle ( handles[1], positions[h?0:1], false ) || state;
+    }
+
+    // Fire the 'slide' event if any handle moved.
+    if ( state ) {
+      fireEvents(['slide']);
+    }
+  }
+
+  // Unbind move events on document, call callbacks.
+  function end ( event ) {
+
+    // The handle is no longer active, so remove the class.
+    $('.' + Classes[15]).removeClass(Classes[15]);
+
+    // Remove cursor styles and text-selection events bound to the body.
+    if ( event.cursor ) {
+      $('body').css('cursor', '').off( namespace );
+    }
+
+    // Unbind the move and end events, which are added on 'start'.
+    doc.off( namespace );
+
+    // Remove dragging class.
+    $Target.removeClass(Classes[12]);
+
+    // Fire the change and set events.
+    fireEvents(['set', 'change']);
+  }
+
+  // Bind move events on document.
+  function start ( event, data ) {
+
+    // Mark the handle as 'active' so it can be styled.
+    if( data.handles.length === 1 ) {
+      data.handles[0].children().addClass(Classes[15]);
+    }
+
+    // A drag should never propagate up to the 'tap' event.
+    event.stopPropagation();
+
+    // Attach the move event.
+    attach ( actions.move, doc, move, {
+      start: event.calcPoint,
+      handles: data.handles,
+      positions: [
+        $Locations[0],
+        $Locations[$Handles.length - 1]
+      ]
+    });
+
+    // Unbind all movement when the drag ends.
+    attach ( actions.end, doc, end, null );
+
+    // Text selection isn't an issue on touch devices,
+    // so adding cursor styles can be skipped.
+    if ( event.cursor ) {
+
+      // Prevent the 'I' cursor and extend the range-drag cursor.
+      $('body').css('cursor', $(event.target).css('cursor'));
+
+      // Mark the target with a dragging state.
+      if ( $Handles.length > 1 ) {
+        $Target.addClass(Classes[12]);
+      }
+
+      // Prevent text selection when dragging the handles.
+      $('body').on('selectstart' + namespace, false);
+    }
+  }
+
+  // Move closest handle to tapped location.
+  function tap ( event ) {
+
+    var location = event.calcPoint, total = 0, to;
+
+    // The tap event shouldn't propagate up and cause 'edge' to run.
+    event.stopPropagation();
+
+    // Add up the handle offsets.
+    $.each( $Handles, function(){
+      total += this.offset()[ options.style ];
+    });
+
+    // Find the handle closest to the tapped position.
+    total = ( location < total/2 || $Handles.length === 1 ) ? 0 : 1;
+
+    location -= $Base.offset()[ options.style ];
+
+    // Calculate the new position.
+    to = ( location * 100 ) / baseSize();
+
+    if ( !options.events.snap ) {
+      // Flag the slider as it is now in a transitional state.
+      // Transition takes 300 ms, so re-enable the slider afterwards.
+      addClassFor( $Target, Classes[14], 300 );
+    }
+
+    // Find the closest handle and calculate the tapped point.
+    // The set handle to the new position.
+    setHandle( $Handles[total], to );
+
+    fireEvents(['slide', 'set', 'change']);
+
+    if ( options.events.snap ) {
+      start(event, { handles: [$Handles[total]] });
+    }
+  }
+
+  // Attach events to several slider parts.
+  function events ( behaviour ) {
+
+    var i, drag;
+
+    // Attach the standard drag event to the handles.
+    if ( !behaviour.fixed ) {
+
+      for ( i = 0; i < $Handles.length; i += 1 ) {
+
+        // These events are only bound to the visual handle
+        // element, not the 'real' origin element.
+        attach ( actions.start, $Handles[i].children(), start, {
+          handles: [ $Handles[i] ]
+        });
+      }
+    }
+
+    // Attach the tap event to the slider base.
+    if ( behaviour.tap ) {
+
+      attach ( actions.start, $Base, tap, {
+        handles: $Handles
+      });
+    }
+
+    // Make the range dragable.
+    if ( behaviour.drag ){
+
+      drag = $Base.find( '.' + Classes[7] ).addClass( Classes[10] );
+
+      // When the range is fixed, the entire range can
+      // be dragged by the handles. The handle in the first
+      // origin will propagate the start event upward,
+      // but it needs to be bound manually on the other.
+      if ( behaviour.fixed ) {
+        drag = drag.add($Base.children().not( drag ).children());
+      }
+
+      attach ( actions.start, drag, start, {
+        handles: $Handles
+      });
+    }
+  }
+
+
+  // Test suggested values and apply margin, step.
+  function setHandle ( handle, to, noLimitOption ) {
+
+    var trigger = handle[0] !== $Handles[0][0] ? 1 : 0,
+      lowerMargin = $Locations[0] + options.margin,
+      upperMargin = $Locations[1] - options.margin,
+      lowerLimit = $Locations[0] + options.limit,
+      upperLimit = $Locations[1] - options.limit;
+
+    // For sliders with multiple handles,
+    // limit movement to the other handle.
+    // Apply the margin option by adding it to the handle positions.
+    if ( $Handles.length > 1 ) {
+      to = trigger ? Math.max( to, lowerMargin ) : Math.min( to, upperMargin );
+    }
+
+    // The limit option has the opposite effect, limiting handles to a
+    // maximum distance from another. Limit must be > 0, as otherwise
+    // handles would be unmoveable. 'noLimitOption' is set to 'false'
+    // for the .val() method, except for pass 4/4.
+    if ( noLimitOption !== false && options.limit && $Handles.length > 1 ) {
+      to = trigger ? Math.min ( to, lowerLimit ) : Math.max( to, upperLimit );
+    }
+
+    // Handle the step option.
+    to = $Spectrum.getStep( to );
+
+    // Limit to 0/100 for .val input, trim anything beyond 7 digits, as
+    // JavaScript has some issues in its floating point implementation.
+    to = limit(parseFloat(to.toFixed(7)));
+
+    // Return false if handle can't move.
+    if ( to === $Locations[trigger] ) {
+      return false;
+    }
+
+    // Set the handle to the new position.
+    handle.css( options.style, to + '%' );
+
+    // Force proper handle stacking
+    if ( handle.is(':first-child') ) {
+      handle.toggleClass(Classes[17], to > 50 );
+    }
+
+    // Update locations.
+    $Locations[trigger] = to;
+
+    // Convert the value to the slider stepping/range.
+    $Values[trigger] = $Spectrum.fromStepping( to );
+
+    linkUpdate(triggerPos[trigger]);
+
+    return true;
+  }
+
+  // Loop values from value method and apply them.
+  function setValues ( count, values ) {
+
+    var i, trigger, to;
+
+    // With the limit option, we'll need another limiting pass.
+    if ( options.limit ) {
+      count += 1;
+    }
+
+    // If there are multiple handles to be set run the setting
+    // mechanism twice for the first handle, to make sure it
+    // can be bounced of the second one properly.
+    for ( i = 0; i < count; i += 1 ) {
+
+      trigger = i%2;
+
+      // Get the current argument from the array.
+      to = values[trigger];
+
+      // Setting with null indicates an 'ignore'.
+      // Inputting 'false' is invalid.
+      if ( to !== null && to !== false ) {
+
+        // If a formatted number was passed, attemt to decode it.
+        if ( typeof to === 'number' ) {
+          to = String(to);
+        }
+
+        to = options.format.from( to );
+
+        // Request an update for all links if the value was invalid.
+        // Do so too if setting the handle fails.
+        if ( to === false || isNaN(to) || setHandle( $Handles[trigger], $Spectrum.toStepping( to ), i === (3 - options.dir) ) === false ) {
+
+          linkUpdate(triggerPos[trigger]);
+        }
+      }
+    }
+  }
+
+  // Set the slider value.
+  function valueSet ( input ) {
+
+    // LibLink: don't accept new values when currently emitting changes.
+    if ( $Target[0].LinkIsEmitting ) {
+      return this;
+    }
+
+    var count, values = asArray( input );
+
+    // The RTL settings is implemented by reversing the front-end,
+    // internal mechanisms are the same.
+    if ( options.dir && options.handles > 1 ) {
+      values.reverse();
+    }
+
+    // Animation is optional.
+    // Make sure the initial values where set before using animated
+    // placement. (no report, unit testing);
+    if ( options.animate && $Locations[0] !== -1 ) {
+      addClassFor( $Target, Classes[14], 300 );
+    }
+
+    // Determine how often to set the handles.
+    count = $Handles.length > 1 ? 3 : 1;
+
+    if ( values.length === 1 ) {
+      count = 1;
+    }
+
+    setValues ( count, values );
+
+    // Fire the 'set' event. As of noUiSlider 7,
+    // this is no longer optional.
+    fireEvents(['set']);
+
+    return this;
+  }
+
+  // Get the slider value.
+  function valueGet ( ) {
+
+    var i, retour = [];
+
+    // Get the value from all handles.
+    for ( i = 0; i < options.handles; i += 1 ){
+      retour[i] = options.format.to( $Values[i] );
+    }
+
+    return inSliderOrder( retour );
+  }
+
+  // Destroy the slider and unbind all events.
+  function destroyTarget ( ) {
+
+    // Unbind events on the slider, remove all classes and child elements.
+    $(this).off(namespace)
+      .removeClass(Classes.join(' '))
+      .empty();
+
+    delete this.LinkUpdate;
+    delete this.LinkConfirm;
+    delete this.LinkDefaultFormatter;
+    delete this.LinkDefaultFlag;
+    delete this.reappend;
+    delete this.vGet;
+    delete this.vSet;
+    delete this.getCurrentStep;
+    delete this.getInfo;
+    delete this.destroy;
+
+    // Return the original options from the closure.
+    return originalOptions;
+  }
+
+  // Get the current step size for the slider.
+  function getCurrentStep ( ) {
+
+    // Check all locations, map them to their stepping point.
+    // Get the step point, then find it in the input list.
+    var retour = $.map($Locations, function( location, index ){
+
+      var step = $Spectrum.getApplicableStep( location ),
+
+        // As per #391, the comparison for the decrement step can have some rounding issues.
+        // Round the value to the precision used in the step.
+        stepDecimals = countDecimals(String(step[2])),
+
+        // Get the current numeric value
+        value = $Values[index],
+
+        // To move the slider 'one step up', the current step value needs to be added.
+        // Use null if we are at the maximum slider value.
+        increment = location === 100 ? null : step[2],
+
+        // Going 'one step down' might put the slider in a different sub-range, so we
+        // need to switch between the current or the previous step.
+        prev = Number((value - step[2]).toFixed(stepDecimals)),
+
+        // If the value fits the step, return the current step value. Otherwise, use the
+        // previous step. Return null if the slider is at its minimum value.
+        decrement = location === 0 ? null : (prev >= step[1]) ? step[2] : (step[0] || false);
+
+      return [[decrement, increment]];
+    });
+
+    // Return values in the proper order.
+    return inSliderOrder( retour );
+  }
+
+  // Get the original set of options.
+  function getOriginalOptions ( ) {
+    return originalOptions;
+  }
+
+
+// Initialize slider
+
+  // Throw an error if the slider was already initialized.
+  if ( $Target.hasClass(Classes[0]) ) {
+    throw new Error('Slider was already initialized.');
+  }
+
+  // Create the base element, initialise HTML and set classes.
+  // Add handles and links.
+  $Base = addSlider( options.dir, options.ort, $Target );
+  $Handles = addHandles( options.handles, options.dir, $Base );
+
+  // Set the connect classes.
+  addConnection ( options.connect, $Target, $Handles );
+
+  // Attach user events.
+  events( options.events );
+
+// Methods
+
+  target.vSet = valueSet;
+  target.vGet = valueGet;
+  target.destroy = destroyTarget;
+
+  target.getCurrentStep = getCurrentStep;
+  target.getOriginalOptions = getOriginalOptions;
+
+  target.getInfo = function(){
+    return [
+      $Spectrum,
+      options.style,
+      options.ort
+    ];
+  };
+
+  // Use the public value method to set the start values.
+  $Target.val( options.start );
+
+}
+
+
+  // Run the standard initializer
+  function initialize ( originalOptions ) {
+
+    // Test the options once, not for every slider.
+    var options = testOptions( originalOptions, this );
+
+    // Loop all items, and provide a new closed-scope environment.
+    return this.each(function(){
+      closure(this, options, originalOptions);
+    });
+  }
+
+  // Destroy the slider, then re-enter initialization.
+  function rebuild ( options ) {
+
+    return this.each(function(){
+
+      // The rebuild flag can be used if the slider wasn't initialized yet.
+      if ( !this.destroy ) {
+        $(this).noUiSlider( options );
+        return;
+      }
+
+      // Get the current values from the slider,
+      // including the initialization options.
+      var values = $(this).val(), originalOptions = this.destroy(),
+
+        // Extend the previous options with the newly provided ones.
+        newOptions = $.extend( {}, originalOptions, options );
+
+      // Run the standard initializer.
+      $(this).noUiSlider( newOptions );
+
+      // Place Link elements back.
+      this.reappend();
+
+      // If the start option hasn't changed,
+      // reset the previous values.
+      if ( originalOptions.start === newOptions.start ) {
+        $(this).val(values);
+      }
+    });
+  }
+
+  // Access the internal getting and setting methods based on argument count.
+  function value ( ) {
+    return this[0][ !arguments.length ? 'vGet' : 'vSet' ].apply(this[0], arguments);
+  }
+
+  // Override the .val() method. Test every element. Is it a slider? Go to
+  // the slider value handling. No? Use the standard method.
+  // Note how $.fn.val expects 'this' to be an instance of $. For convenience,
+  // the above 'value' function does too.
+  $.fn.val = function ( arg ) {
+
+    // this === instanceof $
+
+    function valMethod( a ){
+      return a.hasClass(Classes[0]) ? value : $val;
+    }
+
+    // If no value is passed, this is 'get'.
+    if ( !arguments.length ) {
+      var first = $(this[0]);
+      return valMethod(first).call(first);
+    }
+
+    var isFunction = $.isFunction(arg);
+
+    // Return the set so it remains chainable. Make sure not to break
+    // jQuery's .val(function( index, value ){}) signature.
+    return this.each(function( i ){
+
+      var val = arg, $t = $(this);
+
+      if ( isFunction ) {
+        val = arg.call(this, i, $t.val());
+      }
+
+      valMethod($t).call($t, val);
+    });
+  };
+
+// Extend jQuery/Zepto with the noUiSlider method.
+  $.fn.noUiSlider = function ( options, rebuildFlag ) {
+
+    switch ( options ) {
+      case 'step': return this[0].getCurrentStep();
+      case 'options': return this[0].getOriginalOptions();
+    }
+
+    return ( rebuildFlag ? rebuild : initialize ).call(this, options);
+  };
 
 });


### PR DESCRIPTION
This PR adds the option of `snapDateAt` to the range_slider component, which is specified on the data property of the haml template as `snap_date_at`. 

If this option is provided, the range slider will snap to 24 unit steps rather than allowing the granularity of 1 unit at the value specified in `snap_date_at`.

The reasoning for this is to fix an issue where filters were allowing hour granularity, even though the labels for the filter were showing at the day level of granularity. This caused the UI to send values that would filter out TTD that would appear to the user to be within the selected range.