### PR TITLE
Fix inconsistent button height bug

### DIFF
--- a/app/assets/stylesheets/core/core_components/_buttons.sass
+++ b/app/assets/stylesheets/core/core_components/_buttons.sass
@@ -13,7 +13,8 @@
   padding: 5px 20px
   overflow: hidden
   text-align: center
-  border: none
+  border: 1px solid
+  border-color: transparent
   &:hover
     text-decoration: none
 
@@ -27,19 +28,19 @@
 
 .btn--small
   +btn-font-size(13)
-  padding: 3px 14px
+  padding: 2px 14px
 
 .btn--medium
   +btn-font-size(14)
-  padding: 4px 20px
+  padding: 3px 20px
 
 .btn--large
   +btn-font-size(16)
-  padding: 5px 30px
+  padding: 4px 30px
 
 .btn--x-large
   +btn-font-size(18)
-  padding: 5px 40px
+  padding: 4px 40px
 
 // -----------------------------------------------------------------------------
 // Buttons font modifiers
@@ -79,6 +80,8 @@
   display: inline-block
   margin-right: 5px
   overflow: visible
+  &:last-child
+    margin-right: 0
 
 // -----------------------------------------------------------------------------
 // Button Colors


### PR DESCRIPTION
`.btn--outline` is 2px higher than any other button.

Before:
![screenshot 2015-03-19 01 26 50](https://cloud.githubusercontent.com/assets/1451471/6722256/1ca66574-cdd7-11e4-8305-9177628e77e8.png)
After:
![screenshot 2015-03-19 01 27 05](https://cloud.githubusercontent.com/assets/1451471/6722259/249017a8-cdd7-11e4-9763-8e48307888f7.png)

