### PR TITLE
added @no_nav check for apps that don't need nav bar

### DIFF
--- a/app/views/layouts/responsive.html.haml
+++ b/app/views/layouts/responsive.html.haml
@@ -10,7 +10,8 @@
 
   = render 'layouts/custom/pre_header', third_party: false
   .wrapper.js-wrapper
-    = render 'layouts/custom/post_header', search: true, user_nav: true, include_js: true, nav_primary: true, responsive: true, ads_header: true
+    - unless @no_nav
+      = render 'layouts/custom/post_header', search: true, user_nav: true, include_js: true, nav_primary: true, responsive: true, ads_header: true
 
     .row.row--content{id: @no_wallpaper ? "" : "js-row--content"}
       - if (yield :secondary).present?


### PR DESCRIPTION
This PR allows apps to not use the blue bar (specifically for some BizDev projects).

**Example implementation:**
```
layout "responsive"

def index
    @no_nav = true
    render "mypage"
end
```