### PR TITLE
Adding new ad unit size for bottom of destinations DFP ad

### DIFF
--- a/app/assets/javascripts/lib/core/ad_sizes.js
+++ b/app/assets/javascripts/lib/core/ad_sizes.js
@@ -21,6 +21,10 @@ define(function() {
     mpu: [
       { browser: [ 0, 0 ], ad_sizes: [ 300, 250 ] }
     ],
+    "mpu-bottomboard": [
+      { browser: [ 728, 0 ], ad_sizes: [ 728, 90 ] },
+      { browser: [ 0, 0 ], ad_sizes: [ 300, 250 ] }
+    ],
     "mpu-double": [
       { browser: [ 728, 0 ], ad_sizes: [ [ 300, 600 ], [ 300, 250 ] ] },
       { browser: [ 0, 0 ], ad_sizes: [ 300, 250 ] }

--- a/app/assets/javascripts/lib/core/ad_unit.js
+++ b/app/assets/javascripts/lib/core/ad_unit.js
@@ -35,7 +35,7 @@ define(function() {
   };
 
   AdUnit.prototype.getType = function() {
-    var patterns = /(leaderboard|mpu|trafficDriver|adSense|sponsorTile)/,
+    var patterns = /(leaderboard|mpu-bottomboard|mpu|trafficDriver|adSense|sponsorTile)/,
         matches = this.$target.attr("class").match(patterns);
 
     return matches ? matches[1] : null;


### PR DESCRIPTION
Per Tim Daugherty, the ad unit at bottom on destinations needs to be 728x90 on desktop and 300x250 on mobile.  This adds the new size.