### PR TITLE
Bart tweak pagination

### DIFF
--- a/app/assets/stylesheets/core/core_components/_pagination.sass
+++ b/app/assets/stylesheets/core/core_components/_pagination.sass
@@ -5,13 +5,16 @@
     @extend %rounded-corners
     padding: 8px 20px
 
+.pagination__link,
+.pagination__ellipsis
+  color: $titlegray
+  display: inline-block
+  font-weight: bold
+
 .pagination__link
   border-radius: 5px
   background-color: #fff
   border: 2px solid mix($darkgray, white, 15%)
-  color: $titlegray
-  display: inline-block
-  font-weight: bold
   margin-left: 2px
   padding: 8px 12px
 
@@ -29,14 +32,20 @@
     position: relative
     top: 2px
 
-.pagination__backwards,
-.pagination__forwards
-  min-height: 35px
-  min-width: 100px
-
 .pagination__link--current
   color: $linkblue
-  border-color: $linkblue
+
+  &, &:hover
+    border-color: $linkblue
+
+.pagination__ellipsis
+  vertical-align: top
+  padding: 7px 8px
+
+.pagination__backwards,
+.pagination__forwards
+  min-height: 36px
+  min-width: 40px
 
 .pagination__numbers
   text-align: center

--- a/app/data/styleguide/pagination_stubs.yml
+++ b/app/data/styleguide/pagination_stubs.yml
@@ -2,24 +2,28 @@
   :current_page: 5
   :total_results: 50
   :path: "/styleguide/pagination/%i"
-  :visible_pages: 5
+  :visible_pages: 3
+  :classes: "card"
+-
+  :current_page: 2
+  :total_results: 50
+  :path: "/styleguide/pagination/?foo=bar&baz=qux&page=5"
+  :param: "page"
+  :classes: "card"
+-
+  :current_page: 9
+  :total_results: 50
+  :path: "/styleguide/pagination/?foo=bar&baz=qux&page=5"
+  :param: "page"
+  :classes: "card"
 -
   :current_page: 1
   :total_results: 25
   :path: "/styleguide/pagination/%i"
-  :classes: "additional class-names"
+  :classes: "card"
 -
   :current_page: 5
   :total_results: 25
   :path: "/styleguide/pagination/%i"
--
-  :current_page: 5
-  :total_results: 50
-  :path: "/styleguide/pagination/?foo=bar&baz=qux&page=5"
-  :param: "page"
--
-  :current_page: 5
-  :total_results: 50
-  :path: "/styleguide/pagination/?foo=bar&baz=qux&page=5"
-  :param: "page"
   :show_detailed: true
+  :classes: "card"

--- a/app/views/components/_pagination.html.haml
+++ b/app/views/components/_pagination.html.haml
@@ -13,46 +13,68 @@
 
     .pagination__forwards.split--right
       - if properties[:current_page] < total_pages
-        %a.pagination__link.pagination__link--last{ href: href.gsub(/%i/, total_pages.to_s) }<
-          Last
         %a.pagination__link.pagination__link--next.icon--chevron-right--before{ href: href.gsub(/%i/, (properties[:current_page] + 1).to_s)}
 
     .pagination__backwards.split--left
       - if properties[:current_page] > 1
         %a.pagination__link.pagination__link--prev.icon--chevron-left--before{ href: href.gsub(/%i/, (properties[:current_page] - 1).to_s) }<
-        %a.pagination__link.pagination__link--first{ href: href.gsub(/%i/, "1") }<
-          First
+
+    = single_content_for :pagination_links_rels do
+      - if properties[:current_page] > 1
+        %link{ rel: 'prev', href: href.gsub(/%i/, (properties[:current_page] - 1).to_s) }<
+      - if properties[:current_page] < total_pages
+        %link{ rel: 'next', href: href.gsub(/%i/, (properties[:current_page] + 1).to_s) }<
 
     - if properties[:total_results] > results_per_page
       .pagination__numbers
-        - start = 1
-        - finish = total_pages
+        - start = 2
+        - finish = total_pages - 1
         - num_visible = properties[:visible_pages] || 5
         - offset = (num_visible / 2.0).ceil # Force a floating point number
+        - is_first_page = properties[:current_page] == 1
+        - is_last_page = properties[:current_page] == total_pages
 
-        - if total_pages > num_visible
-          - if properties[:current_page] >= (total_pages - offset) # [x] [x] [x] [x] [√] [√] [c] [√] [√]
-            - start = total_pages - num_visible + 1
-          - elsif properties[:current_page] < offset # [√] [√] [c] [√] [√] [x] [x] [x] [x]
-            - finish = num_visible
-          - else # [x] [√] [√] [c] [√] [√] [x] [x] [x]
+        - if total_pages - 2 > num_visible
+          - if properties[:current_page] >= (total_pages - offset) # [1] ... [√] [√] [c] [√] [√] [n]
+            - start = total_pages - num_visible
+          - elsif properties[:current_page] < offset + 1           # [1] [√] [√] [c] [√] [√] ... [n]
+            - finish = num_visible + 1
+          - else                                                   # [1] ... [√] [√] [c] [√] [√] ... [n]
             - start = properties[:current_page] - offset + 1
             - finish = properties[:current_page] + offset - 1
+
+        - if is_first_page
+          .pagination__link.pagination__link--first.pagination__link--current<
+            1
+        - else
+          %a.pagination__link.pagination__link--first{ href: href.gsub(/%i/, "1") }<
+            1
+
+        - if properties[:current_page] > 2
+          %span.pagination__ellipsis.pagination__ellipsis--left{ class: "#{start <= 2 ? 'mv--hidden' : ''}" }<
+            &#8230;
+
         - for num in start..finish
           - if properties[:current_page] != num
-            %a.pagination__link.mv--inline-block{ href: href.gsub(/%i/, num.to_s), data: { current: properties[:current_page], num: num} }<
+            %a.pagination__link.mv--inline-block{ href: href.gsub(/%i/, num.to_s), data: { current: properties[:current_page], num: num } }<
               = num
           - else
             .pagination__link.pagination__link--current<
               = num
-        = single_content_for :pagination_links_rels do
-          - if (start..finish).cover?(properties[:current_page]-1)
-            %link{rel: 'prev', href: href.gsub(/%i/, (properties[:current_page]-1).to_s)}<
-          - if (start..finish).cover?(properties[:current_page]+1)
-            %link{rel: 'next', href: href.gsub(/%i/, (properties[:current_page]+1).to_s)}<
 
+        - if properties[:current_page] < (total_pages - 1)
+          %span.pagination__ellipsis.pagination__ellipsis--right{ class: "#{finish >= (total_pages - 1) ? 'mv--hidden' : ''}" }<
+            &#8230;
+
+        - if is_last_page
+          .pagination__link.pagination__link--last.pagination__link--current<
+            = total_pages
+        - else
+          %a.pagination__link.pagination__link--last{ href: href.gsub(/%i/, total_pages.to_s) }<
+            = total_pages
 
     - if properties[:show_detailed] && properties[:total_results] > 0
+
       .pagination__detailed-info
         - results_from = ((properties[:current_page]-1) * results_per_page).to_i + 1
         - results_to = ((properties[:current_page]) * results_per_page).to_i

--- a/app/views/styleguide/ui-components/pagination.html.haml
+++ b/app/views/styleguide/ui-components/pagination.html.haml
@@ -7,6 +7,7 @@
     %p
       %strong NB:
       It's important that you include the <code>%i</code> in the path that gets passed through <em>or</em> provide the name of the URL parameter via the <code>param</code> property.
-
+    %p
+      If not specified otherwise, <code>visible_pages</code> property is set to 5.
 - pagination.each_with_index do | stub, i |
   = styleguide_component('pagination', properties: stub, count: i, full_width: true, card_style: true)

--- a/spec/views/components/pagination_spec.rb
+++ b/spec/views/components/pagination_spec.rb
@@ -75,7 +75,7 @@ describe "components/_pagination.html.haml" do
 
     end
 
-    it 'does not render previous and first page links when on the first page' do
+    it 'does not render previous page link when on the first page' do
 
       view.stub(properties: default_properties)
 
@@ -83,7 +83,6 @@ describe "components/_pagination.html.haml" do
 
       rendered.should_not have_css('.pagination__backwards .pagination__link')
       rendered.should_not have_css('.pagination__link--prev')
-      rendered.should_not have_css('.pagination__link--first')
     end
 
   end
@@ -102,7 +101,7 @@ describe "components/_pagination.html.haml" do
 
     end
 
-    it 'does not render next and last page links when on the last page' do
+    it 'does not render next page link when on the last page' do
 
       view.stub(properties: default_properties.merge( :current_page => 5 ))
 
@@ -110,7 +109,6 @@ describe "components/_pagination.html.haml" do
 
       rendered.should_not have_css('.pagination__forwards .pagination__link')
       rendered.should_not have_css('.pagination__link--next')
-      rendered.should_not have_css('.pagination__link--last')
 
     end
 
@@ -148,36 +146,128 @@ describe "components/_pagination.html.haml" do
 
     end
 
-    it 'renders numbers 1-5 given a total of 100 results and current page number of 2' do
+    it 'renders numbers 1-6 & 20 given a total of 100 results and current page number of 2' do
 
       view.stub(properties: default_properties.merge( :total_results => 100, :current_page => 2 ))
 
       render
 
       links = Capybara.string(rendered).all('.pagination__numbers .pagination__link').map { |el| el.text }
-      links.should eq( ['1', '2', '3', '4', '5'] )
+      links.should eq( ['1', '2', '3', '4', '5', '6', '20'] )
 
     end
 
-    it 'renders numbers 8-12 given a total of 100 results and current page number of 10' do
+    it 'renders numbers 1, 8-12 & 20 given a total of 100 results and current page number of 10' do
 
       view.stub(properties: default_properties.merge( :total_results => 100, :current_page => 10 ))
 
       render
 
       links = Capybara.string(rendered).all('.pagination__numbers .pagination__link').map { |el| el.text }
-      links.should eq( ['8', '9', '10', '11', '12'] )
+      links.should eq( ['1', '8', '9', '10', '11', '12', '20'] )
 
     end
 
-    it 'renders numbers 16-20 given a total of 100 results and current page number of 19' do
+    it 'renders numbers 1 & 15-20 given a total of 100 results and current page number of 19' do
 
       view.stub(properties: default_properties.merge( :total_results => 100, :current_page => 19 ))
 
       render
 
       links = Capybara.string(rendered).all('.pagination__numbers .pagination__link').map { |el| el.text }
-      links.should eq( ['16', '17', '18', '19', '20'] )
+      links.should eq( ['1', '15', '16', '17', '18', '19', '20'] )
+
+    end
+
+  end
+
+  describe 'pagination ellipsis' do
+
+    describe 'left' do
+
+      it 'is rendered if current page number is above 2' do
+
+        view.stub(properties: default_properties.merge( :total_results => 100, :current_page => 3 ))
+
+        render
+
+        rendered.should have_css('.pagination__numbers .pagination__ellipsis--left')
+
+      end
+
+      it 'is not rendered if current page number is below or equal 2' do
+
+        view.stub(properties: default_properties.merge( :total_results => 100, :current_page => 2 ))
+
+        render
+
+        rendered.should_not have_css('.pagination__ellipsis--left')
+
+      end
+
+      it 'has "mv--hidden" class if 1st visible page number is succeeding 1st page number' do
+
+        view.stub(properties: default_properties.merge( :total_results => 100, :current_page => 3 ))
+
+        render
+
+        rendered.should have_css('.pagination__ellipsis--left.mv--hidden')
+
+      end
+
+      it 'does not have "mv--hidden" class if 1st visible page number is not succeeding 1st page number' do
+
+        view.stub(properties: default_properties.merge( :total_results => 100, :current_page => 14 ))
+
+        render
+
+        rendered.should_not have_css('.pagination__ellipsis--left.mv--hidden')
+
+      end
+
+    end
+
+    describe 'right' do
+
+      it 'is rendered if current page number is below pre-last page number' do
+
+        view.stub(properties: default_properties.merge( :total_results => 100, :current_page => 4 ))
+
+        render
+
+        rendered.should have_css('.pagination__numbers .pagination__ellipsis--right')
+
+      end
+
+      it 'is not rendered if current page number is last page or one before' do
+
+        view.stub(properties: default_properties.merge( :total_results => 100, :current_page => 19 ))
+
+        render
+
+        rendered.should_not have_css('.pagination__ellipsis--right')
+
+      end
+
+      it 'has "mv--hidden" class if the last of visible pages is preceding last page' do
+
+        view.stub(properties: default_properties.merge( :total_results => 100, :current_page => 17 ))
+
+        render
+
+        rendered.should have_css('.pagination__ellipsis--right.mv--hidden')
+
+      end
+
+      it 'does not have "mv--hidden" class if the last of visible pages is not preceding last page' do
+
+        view.stub(properties: default_properties.merge( :total_results => 100, :current_page => 8 ))
+
+        render
+
+        rendered.should_not have_css('.pagination__ellipsis--right.mv--hidden')
+
+      end
 
     end
 
@@ -204,6 +294,7 @@ describe "components/_pagination.html.haml" do
       render
 
       links = Capybara.string(rendered).all('.pagination__numbers a.pagination__link').map { |el| el[:href] }
+
       links.should eq( [
         '/path/to/page?foo=bar&baz=qux&page=2',
         '/path/to/page?foo=bar&baz=qux&page=3',


### PR DESCRIPTION
Replaced `first` & `last` buttons with actual numbers in order to let user know how much content he's dealing with. Added some ellipsis there :]

**ABOVE MV**

![screenshot 2015-04-08 14 56 02](https://cloud.githubusercontent.com/assets/1451471/7048260/302c9942-de12-11e4-8b8c-736398a26a97.png)
![screenshot 2015-04-08 14 57 10](https://cloud.githubusercontent.com/assets/1451471/7048262/302dc006-de12-11e4-9d30-a71f21e14e98.png)
![screenshot 2015-04-08 14 56 47](https://cloud.githubusercontent.com/assets/1451471/7048261/302e0994-de12-11e4-9833-a2d059b660c0.png)
![screenshot 2015-04-08 14 57 48](https://cloud.githubusercontent.com/assets/1451471/7048263/302ec852-de12-11e4-8e4c-d0c49b72f5d6.png)
![screenshot 2015-04-08 14 58 06](https://cloud.githubusercontent.com/assets/1451471/7048264/3031868c-de12-11e4-9d26-709cc5f58f33.png)

**BELOW MV**

![screenshot 2015-04-08 18 33 10](https://cloud.githubusercontent.com/assets/1451471/7050116/61e0fca0-de1f-11e4-80dc-c17fa62a0fba.png)
![screenshot 2015-04-08 18 28 54](https://cloud.githubusercontent.com/assets/1451471/7050119/61ead13a-de1f-11e4-8166-d7b296413252.png)
![screenshot 2015-04-08 18 29 11](https://cloud.githubusercontent.com/assets/1451471/7050114/61decf3e-de1f-11e4-9298-adf8c15af889.png)
![screenshot 2015-04-08 18 29 26](https://cloud.githubusercontent.com/assets/1451471/7050118/61e111f4-de1f-11e4-9e88-5710fe804d4c.png)
![screenshot 2015-04-08 18 32 44](https://cloud.githubusercontent.com/assets/1451471/7050117/61e11eb0-de1f-11e4-9a77-a307607a1176.png)
