### PR TITLE
Fix no-3d-support

### DIFF
--- a/app/assets/javascripts/lib/core/feature_detect.js
+++ b/app/assets/javascripts/lib/core/feature_detect.js
@@ -101,10 +101,10 @@ define([ "jquery" ], function($) {
   features.transform = function() {
     var
       transforms = {
+        transform: "transform",
         webkitTransform: "-webkit-transform",
         MozTransform: "-moz-transform",
-        msTransform: "-ms-transform",
-        transform: "transform"
+        msTransform: "-ms-transform"
       },
       transform;
 

--- a/app/assets/javascripts/lib/core/feature_detect.js
+++ b/app/assets/javascripts/lib/core/feature_detect.js
@@ -42,7 +42,7 @@ define([ "jquery" ], function($) {
     document.body.insertBefore(el, document.body.firstChild);
 
     if (transform) {
-      el.style[transform.css] = "translate3d(1px,1px,1px)";
+      el.style[transform.js] = "translate3d(1px,1px,1px)";
       has3d = window.getComputedStyle(el).getPropertyValue(transform.css);
     }
 


### PR DESCRIPTION
@stevebrownlee Can someone on your team take a look at this one?

I am seeing `no-3d-support` on the html element which is wrong since `translate3d()` has been available in Firefox for a while.

I've updated feature_detect.js to address this issue.