### PR TITLE
Implement Amazon script tags for whitelisted test page in Gonzo

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -173,6 +173,7 @@ module.exports = function(grunt) {
                 pickadate: "./vendor/assets/javascripts/pickadate",
                 polyfills: "./vendor/assets/javascripts/polyfills",
                 usabilla: "./vendor/assets/javascripts/usabilla",
+                amazon: "./vendor/assets/javascripts/amazon",
                 picker: "vendor/assets/javascripts/pickadate/lib/picker",
                 pickerDate: "./vendor/assets/javascripts/pickadate/lib/picker.date",
                 pickerLegacy: "./vendor/assets/javascripts/pickadate/lib/legacy",

--- a/app/views/layouts/partials/inline_js/_a9.html
+++ b/app/views/layouts/partials/inline_js/_a9.html
@@ -1,0 +1,23 @@
+<script type='text/javascript' src='https://c.amazon-adsystem.com/aax2/amzn_ads.js'></script>
+<script type='text/javascript'>
+    try {
+        amznads.getAds('3231');
+    } catch(e) {
+      console.log(e);
+    }
+</script>
+
+<script type='text/javascript'>
+var key = 'amznslots';
+var values = amznads.getTokens(); //comma separated tokens
+// IMPORTANT: Pass key, values defined above as custom-targeting key-value pairs into your Ad-Server call.
+</script>
+
+<script type='text/javascript'>
+  try {
+    amznads.setTargetingForGPTAsync('amznslots');
+  } catch(e) {
+    console.log(e);
+  }
+</script>
+

--- a/app/views/layouts/partials/snippets/_head_js.haml
+++ b/app/views/layouts/partials/snippets/_head_js.haml
@@ -84,6 +84,7 @@
 
 = render 'layouts/partials/inline_js/load_css'
 = render 'layouts/partials/inline_js/krux'
+= render 'layouts/partials/inline_js/a9'
 
 :javascript
   // Google analytics

--- a/vendor/assets/javascripts/amazon/a9.js
+++ b/vendor/assets/javascripts/amazon/a9.js
@@ -1,0 +1,10 @@
+require(["http://c.amazon-adsystem.com/aax2/amzn_ads.js"], function (amzn) {
+
+  "use strict";
+
+  try {
+    var amazon_ads = amznads.getAds('3231');
+  } catch(e) {
+    console.log(e);
+  }
+});


### PR DESCRIPTION
> Trello issue: https://trello.com/c/N6zvUvbv/3-implementation-of-a9-amazon-technology

## Description

For our AdOps team, we need to implement the ability for our DFP implementation to also call out to Amazon for bids on our ads.

## Verification

1. Pull down related code for Gonzo (https://github.com/lonelyplanet/gonzo/pull/49)
2. Pull down this PR code
3. In Gonzo, point to local rizzo
4. Open the `a9_test` page
5. Verify in your Network tab traffic that there is a bid request sent to Amazon