### PR TITLE
Support Apple campaign ad sizes

### DIFF
--- a/app/assets/javascripts/lib/core/ad_sizes.js
+++ b/app/assets/javascripts/lib/core/ad_sizes.js
@@ -10,7 +10,7 @@ define(function() {
       { browser: [ 0, 0 ], ad_sizes: [ 320, 50 ] }
     ],
     leaderboard: [
-      { browser: [ 980, 0 ], ad_sizes: [ [ 970, 66 ], [ 728, 90 ] ] },
+      { browser: [ 980, 0 ], ad_sizes: [ [ 970, 250 ], [ 970, 300 ], [ 970, 66 ], [ 728, 90 ] ] },
       { browser: [ 728, 0 ], ad_sizes: [ 728, 90 ] },
       { browser: [ 0, 0 ], ad_sizes: [ 320, 50 ] }
     ],
@@ -19,14 +19,14 @@ define(function() {
       { browser: [ 0, 0 ], ad_sizes: [ 320, 50 ] }
     ],
     mpu: [
-      { browser: [ 0, 0 ], ad_sizes: [ 300, 250 ] }
+      { browser: [ 0, 0 ], ad_sizes: [ [ 1, 1 ], [ 300, 250 ] ] }
     ],
     "mpu-bottomboard": [
-      { browser: [ 728, 0 ], ad_sizes: [ 728, 90 ] },
+      { browser: [ 728, 0 ], ad_sizes: [ [ 1, 1 ], [ 728, 90 ] ] },
       { browser: [ 0, 0 ], ad_sizes: [ 300, 250 ] }
     ],
     "mpu-double": [
-      { browser: [ 728, 0 ], ad_sizes: [ [ 300, 600 ], [ 300, 250 ] ] },
+      { browser: [ 728, 0 ], ad_sizes: [ [ 1, 1 ], [ 300, 600 ], [ 300, 250 ] ] },
       { browser: [ 0, 0 ], ad_sizes: [ 300, 250 ] }
     ],
     "sponsor-logo": [


### PR DESCRIPTION
The new sizes are to support the Apple campaign headed our way.  The [1,1] sizes will allow the AdOps team to not show the MPU unit and bottom unit in Destinations and Homepage.

