### PR TITLE
Fix google breadcrumbs

### DIFF
--- a/app/assets/javascripts/app_core.js
+++ b/app/assets/javascripts/app_core.js
@@ -6,6 +6,8 @@ define([
   "sCode",
   "trackjs",
   "polyfills/xdr",
+  "polyfills/function_bind",
+  "polyfills/array_index_of",
   "lib/page/swipe",
   "lib/core/nav_search",
   "lib/page/scroll_perf",
@@ -13,7 +15,6 @@ define([
   "lib/core/shopping_cart",
   "lib/core/feature_detect",
   "lib/core/place_title_nav",
-  "polyfills/function_bind",
   "lib/core/cookie_compliance",
   "lib/components/toggle_active",
   "lib/components/select_group_manager"

--- a/app/views/components/navigation/_breadcrumbs.html.haml
+++ b/app/views/components/navigation/_breadcrumbs.html.haml
@@ -1,17 +1,26 @@
 - icon_class = properties[:icon] ? "breadcrumbs--icon icon--#{properties[:icon]}--before" : ""
 
-.nav--inline{ itemscope: true, itemtype: "http://data-vocabulary.org/Breadcrumb", class: icon_class }
+.nav--inline{ class: icon_class }
 
   - if properties[:show_home]
-    %a.nav__item.nav__item--breadcrumbs--home.icon--home{href: '/', itemprop:"url"}> Home
+    %a.nav__item.nav__item--breadcrumbs--home.icon--home{href: '/'}> Home
 
   - properties[:breadcrumbs].each_with_index do |breadcrumb, index|
     - last = properties[:breadcrumbs].length == (index + 1)
 
     - if breadcrumb[:slug] && !last
-      %a.nav__item.js-nav-item.nav__item--breadcrumbs{itemprop: "url", href: "http://www.lonelyplanet.com/#{breadcrumb[:slug]}"}<>
+      %a.nav__item.js-nav-item.nav__item--breadcrumbs{href: "http://www.lonelyplanet.com/#{breadcrumb[:slug]}"}<>
         = breadcrumb[:place]
       
     - else
       %span.nav__item.js-nav-item.nav__item--breadcrumbs{class: last ? "current" : false}<>
         = breadcrumb[:place]
+
+  -# invisible navigation for Google Breadcrumbs
+  .google-breadcrumbs.is-hidden
+    - google_breadcrumbs = properties[:breadcrumbs].select {|item| !!(item[:slug] && item[:place])}[0..-2]
+    - google_breadcrumbs.each_with_index do |breadcrumb, index|
+      %div{id: "google-breadcrumb-#{index}", itemscope: true, itemprop:"child", itemtype: 'http://data-vocabulary.org/Breadcrumb', itemref: (!!google_breadcrumbs[index+1] ? "google-breadcrumb-#{index+1}" : nil)}
+        %a{href: "http://www.lonelyplanet.com/#{breadcrumb[:slug]}", itemprop: "url"}
+          %span{itemprop: "title"}
+            = breadcrumb[:place]

--- a/vendor/assets/javascripts/polyfills/array_index_of.js
+++ b/vendor/assets/javascripts/polyfills/array_index_of.js
@@ -1,0 +1,65 @@
+// Production steps of ECMA-262, Edition 5, 15.4.4.14
+// Reference: http://es5.github.io/#x15.4.4.14
+if (!Array.prototype.indexOf) {
+  Array.prototype.indexOf = function(searchElement, fromIndex) {
+
+    var k;
+
+    // 1. Let O be the result of calling ToObject passing
+    //    the this value as the argument.
+    if (this == null) {
+      throw new TypeError('"this" is null or not defined');
+    }
+
+    var O = Object(this);
+
+    // 2. Let lenValue be the result of calling the Get
+    //    internal method of O with the argument "length".
+    // 3. Let len be ToUint32(lenValue).
+    var len = O.length >>> 0;
+
+    // 4. If len is 0, return -1.
+    if (len === 0) {
+      return -1;
+    }
+
+    // 5. If argument fromIndex was passed let n be
+    //    ToInteger(fromIndex); else let n be 0.
+    var n = +fromIndex || 0;
+
+    if (Math.abs(n) === Infinity) {
+      n = 0;
+    }
+
+    // 6. If n >= len, return -1.
+    if (n >= len) {
+      return -1;
+    }
+
+    // 7. If n >= 0, then Let k be n.
+    // 8. Else, n<0, Let k be len - abs(n).
+    //    If k is less than 0, then let k be 0.
+    k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+
+    // 9. Repeat, while k < len
+    while (k < len) {
+      // a. Let Pk be ToString(k).
+      //   This is implicit for LHS operands of the in operator
+      // b. Let kPresent be the result of calling the
+      //    HasProperty internal method of O with argument Pk.
+      //   This step can be combined with c
+      // c. If kPresent is true, then
+      //    i.  Let elementK be the result of calling the Get
+      //        internal method of O with the argument ToString(k).
+      //   ii.  Let same be the result of applying the
+      //        Strict Equality Comparison Algorithm to
+      //        searchElement and elementK.
+      //  iii.  If same is true, return k.
+      if (k in O && O[k] === searchElement) {
+        return k;
+      }
+      k++;
+    }
+    return -1;
+  };
+}


### PR DESCRIPTION
Remove old breadcrumbs as these were invalid and replace with new ones.

For reference:
https://developers.google.com/structured-data/breadcrumbs

Example output:

```
<div class="google-breadcrumbs is-hidden">
  <div id="google-breadcrumb-0" itemprop="child" itemref="google-breadcrumb-1" itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb">
    <a href="http://www.lonelyplanet.com/thorntree" itemprop="url">
      <span itemprop="title">
        Thorn Tree
      </span>
    </a>
  </div>
  <div id="google-breadcrumb-1" itemprop="child" itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb">
    <a href="http://www.lonelyplanet.com//thorntree/categories/country-forums" itemprop="url">
      <span itemprop="title">
        Country forums
      </span>
    </a>
  </div>
</div>
```

passes validation and produces valid output using:
https://developers.google.com/structured-data/testing-tool/

Does not include "Home" breadcrumb, it doesn't make much sense because
site name is going to be used by google anyways.

Does not include very last item because this is going to be a page
title and is not really a proper breadcrumb.

The final output for above example would be:
`www.lonelyplanet.com > Thorn Tree > Country forums`