### PR TITLE
More refined enhancements for Apple campaign

### DIFF
--- a/app/assets/javascripts/lib/core/ad_sizes.js
+++ b/app/assets/javascripts/lib/core/ad_sizes.js
@@ -10,7 +10,7 @@ define(function() {
       { browser: [ 0, 0 ], ad_sizes: [ 320, 50 ] }
     ],
     leaderboard: [
-      { browser: [ 980, 0 ], ad_sizes: [ [ 1001, 300 ], [ 970, 250 ], [ 970, 66 ], [ 728, 90 ] ] },
+      { browser: [ 980, 0 ], ad_sizes: [ [ 970, 250 ], [ 970, 66 ], [ 728, 90 ] ] },
       { browser: [ 728, 0 ], ad_sizes: [ 728, 90 ] },
       { browser: [ 0, 0 ], ad_sizes: [ 320, 50 ] }
     ],

--- a/app/assets/stylesheets/components/_stack.sass
+++ b/app/assets/stylesheets/components/_stack.sass
@@ -60,7 +60,7 @@
     margin-left: auto
     margin-right: auto
     min-width: 300px
-    background: $subduedgray
+    background: $body-background
     +respond-to(wide-view)
       display: block
       min-width: 0


### PR DESCRIPTION
Remove the 1001x300 size for the leaderboard slot since that's not what we're targeting.  Also making the MPU ad on the side rail have the same bgcolor as the body so that when it is set to 1x1, it's not obtrusive by having a different background color.