### PR TITLE
Remove 908px media query for ads

### DIFF
--- a/app/assets/stylesheets/core/layouts/modern/_ads.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_ads.sass
@@ -31,9 +31,6 @@
   display: table
   margin-left: auto
   margin-right: auto
-  +respond-to(728 + 180)
-    padding-left: 90px
-    padding-right: 90px
 
 .ad-leaderboard__bottom
   position: relative


### PR DESCRIPTION
Removing the padding media query for leaderboard ads for the duration of the Apple campaign so that the extra-wide ad remains centered as the browser size changes. JIRA ticket created to roll this back after the campaign. 

> JIRA ticket: https://lonelyplanet.atlassian.net/browse/LPMC-32

Note: this will be pushed to Homepage, and possibly Destinations, at 7pm tonight

## Verification

1. Modify Waldorf to point to local Rizzo
2. Fire up Waldorf and visit localhost:8080/asia
3. Wait for the ads the load
4. Resize the browser and ensure that the ads always stays centered and does not get extra padding above 908px