### PR TITLE
Make sure Essential information is not double tracked

### DIFF
--- a/app/assets/javascripts/lib/analytics/travel_insurance_omniture.js
+++ b/app/assets/javascripts/lib/analytics/travel_insurance_omniture.js
@@ -3,8 +3,9 @@ require([ "jquery", "lib/analytics/analytics" ], function($, Analytics) {
   "use strict";
 
   var analytics = new Analytics();
-
-  analytics.trackView();
+  if (window.lp.hasOwnProperty("tracking") && window.lp.tracking.hasOwnProperty("eVar12") && window.lp.tracking.eVar12 !== "dest essential information") {
+    analytics.trackView();
+  }
 
   // Set up Omniture event handlers
 


### PR DESCRIPTION
Don't run `trackView` on need-to-know views if they're already being tracked.