### PR TITLE
show notification to destinations-next alpha testers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,12 @@ grunt ci
 
 It should look like...
 ![](http://d.pr/i/jSY4+)
+
+##Run tests
+```shell
+grunt ci
+grunt jshint
+grunt jscs
+bundle exec rspec
+bundle exec cucumber
+

--- a/app/helpers/global_resources_helper.rb
+++ b/app/helpers/global_resources_helper.rb
@@ -32,4 +32,9 @@ module GlobalResourcesHelper
       end
     end
   end
+
+  def destinations_next_cookie?
+    cookies[:destinations_next_cookie]
+  end
+
 end

--- a/app/views/layouts/responsive.html.haml
+++ b/app/views/layouts/responsive.html.haml
@@ -8,6 +8,9 @@
   %script#tmpl-preloader{ type: 'text/html' }
     = ui_component('preloader')
 
+  - if destinations_next_cookie?
+    = ui_component('alert', properties: {type: "warning",title: "Dear alpha tester, ",message: "you've left the new experience."})
+    
   = render 'layouts/custom/pre_header', third_party: false
   .wrapper.js-wrapper
     - unless @no_nav


### PR DESCRIPTION
Notification :point_down:  should show up if a cookie called `destinations_next_cookie` is set
<img width="1405" alt="screen shot 2015-07-08 at 8 19 35 pm" src="https://cloud.githubusercontent.com/assets/2614324/8585956/b2a7b242-25ae-11e5-9960-ce2b10d5c691.png">