### PR TITLE
Remove border bottom from last  of type

### DIFF
--- a/app/assets/stylesheets/rizzo_next/_base_mixins.scss
+++ b/app/assets/stylesheets/rizzo_next/_base_mixins.scss
@@ -48,6 +48,10 @@
   @media (min-width: $min-1080){
     padding: ($gutter*4.5) 0 ($gutter*4.5 - $spacing);
   }
+
+  &--border-bottom:last-of-type:after {
+    border: 0;
+  }
 }
 
 @mixin container() {


### PR DESCRIPTION
Fixes issue where an extra bottom border line was being drawn when tours component was not present. This universally removes any bottom border from a component that is the last one before the footer.

Addresses this card: https://lonelyplanet.atlassian.net/browse/DCV-289