### PR TITLE
Remove loading indication from autocomplete

### DIFF
--- a/app/assets/stylesheets/components/_autocomplete.sass
+++ b/app/assets/stylesheets/components/_autocomplete.sass
@@ -6,14 +6,6 @@
 
 .autocomplete
   position: relative
-  input, textarea
-    background-image: url("#{image_path('shared/spinner.gif')}")
-    background-repeat: no-repeat
-    background-position: right 5px top 11px
-    background-size: 0
-  &.is-loading 
-    input, textarea
-      background-size: 40px
 
 .autocomplete__results
   +z-layer(middle)

--- a/app/assets/stylesheets/core/_inputs.sass
+++ b/app/assets/stylesheets/core/_inputs.sass
@@ -148,16 +148,6 @@ input[type="submit"]
     background-position: 0 -28px
     @if $is-ie
       background-position: 0 0
-  .is-loading + &
-    animation: pulse 1s ease infinite
-
-  @keyframes "pulse"
-    0%
-      opacity: 1
-    50%
-      opacity: 0.05
-    100%
-      opacity: 1
 
 .primary-search-autocomplete
   .autocomplete__results


### PR DESCRIPTION
This decreases CPU usage significantly (reported as a bug). Tried to replace it with something less demanding (-_-) but ended up deleting it. It wasn't of much use anyways - results are fetched before it's fully appeared. 

:fire: :fire: :fire: 