### PR TITLE
Dont overwrite pageName when tracking flights widget click event

### DIFF
--- a/app/assets/javascripts/lib/analytics/flights_omniture.js
+++ b/app/assets/javascripts/lib/analytics/flights_omniture.js
@@ -11,7 +11,8 @@ define([ "jquery" ], function($) {
 
     this.initHandlers();
 
-    window.s.pageName = "bookings services : flights";
+    if (!window.s.pageName)
+      window.s.pageName = "bookings services : flights";
     window.s.channel = "bookings services";
     window.s.eVar2 = "bookings services";
     window.s.eVar4 = "flights";


### PR DESCRIPTION
`pageName` param in `flights_omniture` script shouldnt be overwritten when the` pageName` value is already present. This messed up statistics for flights widget in Essential Information
Jira ticket: https://lonelyplanet.atlassian.net/browse/LPMC-70