### PR TITLE
Bart add custom title to secondary nav

### DIFF
--- a/app/assets/stylesheets/core/layouts/modern/_secondary_nav.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_secondary_nav.sass
@@ -103,7 +103,7 @@
 
 
 .nav--secondary__other-toggle
-  +font-size(13)
+  +font-size(14)
   color: $lightgray
   display: block
   font-weight: bold

--- a/app/views/components/navigation/_secondary.html.haml
+++ b/app/views/components/navigation/_secondary.html.haml
@@ -1,4 +1,8 @@
-- responsive_items = properties[:responsive_items]
+:ruby
+  custom_title = properties[:custom_title]
+  responsive_items = properties[:responsive_items]
+  items = responsive_items || properties[:items]
+  current_item = (items.find {|i| i[:current]} || items.first)[:title]
 
 .nav--secondary__container
   -# The secondary navigation for small screens
@@ -6,13 +10,11 @@
     .grid-wrapper--0
       .col--one-half
         .nav--secondary__col.nav--secondary__title.copy--h4
-          - if !!responsive_items
-            = (responsive_items.find {|i| i[:current]} || responsive_items.first)[:title]
-          - else
-            = (properties[:items].find {|i| i[:current]} || properties[:items].first)[:title]
+          = !!custom_title ? custom_title.html_safe : current_item
+
       .col--one-half
         %a.nav--secondary__other-toggle.nav--secondary__col.js-toggle-active{ data: { toggle_target: ".js-secondary-nav-other-menu", toggle_me: "true" } }
-          Other sections
+          = !!custom_title ? "Sections" : "Other sections"
           %span.nav--secondary__other-toggle--icon.icon--chevron-down.icon--body-grey
           %span.nav--secondary__other-toggle--icon.icon--chevron-up.icon--body-grey
 


### PR DESCRIPTION
It adds option to add custom title (html_safe) to be displayed instead of selected item. We'd like use it in Community to save some precious space. 

It's backwards compatible, won't blow anything anywhere up (I hope so :trolleybus:).


Before: 

![screenshot 2015-08-25 00 53 30](https://cloud.githubusercontent.com/assets/1451471/9454636/c3d0f35a-4ac3-11e5-9eb9-1356557f7baf.png)


After:

![screenshot 2015-08-25 00 50 38](https://cloud.githubusercontent.com/assets/1451471/9454587/65cf59ae-4ac3-11e5-868f-3a93faf20b94.png)
