### PR TITLE
adds html safe so form labels can include html

### DIFF
--- a/app/views/components/forms/_checkbox_field.html.haml
+++ b/app/views/components/forms/_checkbox_field.html.haml
@@ -7,7 +7,7 @@
       - if properties[:tooltip]
         = render :partial => 'components/forms/partials/tooltip', :locals => { tooltip: properties[:tooltip] }
       %label.js-field-label{ for: properties[:id] }<
-        = properties[:label]
+        = properties[:label].html_safe
       - if properties[:error]
         .field__error.js-error
           = properties[:error]


### PR DESCRIPTION
This adds .html_safe class to form labels.  Please check that html can be added in yml inputs and renders as such.