### PR TITLE
Working on code to add beta banner for Destinations Next

### DIFF
--- a/app/assets/javascripts/app_core.js
+++ b/app/assets/javascripts/app_core.js
@@ -2,6 +2,7 @@ define([
   "jquery",
   "flamsteed",
   "lib/core/ad_manager",
+  "lib/utils/local_store",
 
   "sCode",
   "trackjs",
@@ -21,7 +22,7 @@ define([
   "lib/components/toggle_active",
   "lib/components/select_group_manager"
 
-], function($, Flamsteed, AdManager) {
+], function($, Flamsteed, AdManager, LocalStore) {
 
   "use strict";
 
@@ -47,6 +48,8 @@ define([
 
     // BETA
     $(document).on("click", ".js-beta-link", function(e) {
+      var ls = new LocalStore();
+
       if (window.lp.fs) {
         window.lp.fs.log({
           d: JSON.stringify({
@@ -55,7 +58,7 @@ define([
           })
         });
       }
-      document.cookie = [ "_v", "split-12-destinations-next" ].join("=");
+      ls.setCookie("_v", "split-12-destinations-next", 14);
       window.location.reload();
 
       e.preventDefault();

--- a/app/assets/javascripts/app_core.js
+++ b/app/assets/javascripts/app_core.js
@@ -45,6 +45,22 @@ define([
       });
     }
 
+    // BETA
+    $(document).on("click", ".js-beta-link", function(e) {
+      if (window.lp.fs) {
+        window.lp.fs.log({
+          d: JSON.stringify({
+            name: "beta registration",
+            referrer: window.location.href
+          })
+        });
+      }
+      document.cookie = [ "_v", "split-12-destinations-next" ].join("=");
+      window.location.reload();
+
+      e.preventDefault();
+    });
+
     // Navigation tracking
     $("#js-primary-nav").on("click", ".js-nav-item", function() {
       window.s.linkstacker($(this).text());

--- a/app/helpers/beta_helper.rb
+++ b/app/helpers/beta_helper.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 # BETA
 module BetaHelper
   def place?

--- a/app/helpers/beta_helper.rb
+++ b/app/helpers/beta_helper.rb
@@ -1,8 +1,7 @@
 # BETA
 module BetaHelper
   def place?
-    presenter ||= nil
-    presenter.is_a?(PlacePresenter) if presenter
+    presenter.is_a?(PlacePresenter) if defined?(presenter)
   end
   alias_method :is_place?, :place?
 

--- a/app/helpers/beta_helper.rb
+++ b/app/helpers/beta_helper.rb
@@ -1,7 +1,10 @@
+require 'pry'
+
 # BETA
 module BetaHelper
   def place?
-    presenter && presenter.is_a?(PlacePresenter)
+    presenter ||= nil
+    presenter.is_a?(PlacePresenter) if presenter
   end
   alias_method :is_place?, :place?
 

--- a/app/helpers/beta_helper.rb
+++ b/app/helpers/beta_helper.rb
@@ -1,0 +1,13 @@
+# BETA
+module BetaHelper
+  def place?
+    presenter && presenter.is_a?(PlacePresenter)
+  end
+  alias_method :is_place?, :place?
+
+  def show_beta_banner
+    return 1.0 if params[:beta] == 'destinations-next'
+
+    rand < 0.0025
+  end
+end

--- a/app/views/layouts/responsive.html.haml
+++ b/app/views/layouts/responsive.html.haml
@@ -9,7 +9,9 @@
     = ui_component('preloader')
   
   - if is_place? && show_beta_banner
-    = ui_component('alert', properties: { type: "warning", title: "", message: "Explore our new destinations experience. <a href='/' class='js-beta-link'>Switch to Beta.</a>" })
+    = ui_component('alert', properties: { type: "warning", title: "", message: "Explore our new destinations experience. <a href='#' class='js-beta-link'>Switch to Beta.</a>" })
+  - elsif destinations_next_cookie?
+    = ui_component('alert', properties: { type: "warning",title: "Dear alpha tester, ",message: "you've left the new experience." })
     
   = render 'layouts/custom/pre_header', third_party: false
   .wrapper.js-wrapper

--- a/app/views/layouts/responsive.html.haml
+++ b/app/views/layouts/responsive.html.haml
@@ -7,9 +7,9 @@
   = ui_component('lightbox')
   %script#tmpl-preloader{ type: 'text/html' }
     = ui_component('preloader')
-
-  - if destinations_next_cookie?
-    = ui_component('alert', properties: {type: "warning",title: "Dear alpha tester, ",message: "you've left the new experience."})
+  
+  - if is_place? && show_beta_banner
+    = ui_component('alert', properties: { type: "warning", title: "", message: "Explore our new destinations experience. <a href='/' class='js-beta-link'>Switch to Beta.</a>" })
     
   = render 'layouts/custom/pre_header', third_party: false
   .wrapper.js-wrapper

--- a/app/views/layouts/responsive.html.haml
+++ b/app/views/layouts/responsive.html.haml
@@ -11,7 +11,7 @@
   - if is_place? && show_beta_banner
     = ui_component('alert', properties: { type: "warning", title: "", message: "Explore our new destinations experience. <a href='#' class='js-beta-link'>Switch to Beta.</a>" })
   - elsif destinations_next_cookie?
-    = ui_component('alert', properties: { type: "warning",title: "Dear alpha tester, ",message: "you've left the new experience." })
+    = ui_component('alert', properties: { type: "warning",title: "Dear beta tester, ",message: "you've left the new experience." })
     
   = render 'layouts/custom/pre_header', third_party: false
   .wrapper.js-wrapper


### PR DESCRIPTION
You can test this PR by setting rizzo local in waldorf.
Then go to any destination page with `?beta=destinations-next` in the URL.
Verify after clicking the link in the banner that a cookie with `_v` set to `split-12-destinations-next` is correctly set.