### PR TITLE
Bart new feed popups

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -147,10 +147,9 @@ module.exports = function(grunt) {
         options: {
           host: "http://127.0.0.1:8888/",
           helpers: [
-            "./spec/javascripts/helpers/bind_polyfill.js",
             "./vendor/assets/javascripts/jquery/dist/jquery.js",
-            "./spec/javascripts/helpers/jasmine-jquery.js",
-            "./spec/javascripts/helpers/SpecHelper.js"
+            "node_modules/jasmine-ajax/lib/mock-ajax.js",
+            "./spec/javascripts/helpers/**/*.js"
           ],
           template: require("grunt-template-jasmine-requirejs"),
           specs: "./public/assets/javascripts/spec/**/*_spec.js",

--- a/app/assets/javascripts/lib/core/user_feed.js
+++ b/app/assets/javascripts/lib/core/user_feed.js
@@ -1,282 +1,90 @@
-// ------------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 //
 // User Feed
 //
-// ------------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 define([
   "jquery",
-  "lib/utils/template",
+  "lib/utils/debounce",
   "lib/components/tabs",
-  "lib/core/timeago"
-], function($, Template, Tabs, TimeAgo) {
+  "./user_feed/flyout",
+  "./user_feed/fetcher",
+  "./user_feed/content",
+  "./user_feed/unread_counter",
+  "./user_feed/popups"
+], function($, debounce, Tabs, Flyout, Fetcher,
+            Content, UnreadCounter, Popups) {
 
   "use strict";
 
   var defaults = {
-        feedUrl: "https://www.lonelyplanet.com/thorntree/users/feed",
-        maxFeedActivities: 5,
-        fetchInterval: 15000,
-        selectors: {
-          feedContent: ".js-user-feed-content",
-          feedItem: ".js-user-feed-item",
-          flyoutTrigger: ".js-user-signed-in",
-          flyout: ".js-user-feed",
-          tabsContent: ".js-tabs-content",
-          targetLink: ".js-user-feed-item-target-link",
-          activities: "#js-user-feed-activities-list",
-          messages: "#js-user-feed-messages-list",
-          messagesResponsiveMenuItem: ".js-responsive-messages",
-          footer: ".js-user-feed-footer",
-          unreadFeedNumber: ".js-unread-feed-count",
-          unreadActivitiesNumber: ".js-unread-activities-count",
-          unreadMessagesNumber: ".js-unread-messages-count",
-          unreadMessagesResponsiveNumber: ".js-responsive-unread-messages"
-        }
-      },
-      _selectors;
+    el:      ".js-user-feed",
+    ajaxUrl: "https://www.lonelyplanet.com/thorntree/users/feed"
+  };
 
   function UserFeed(args) {
     this.config = $.extend({}, defaults, args);
-    _selectors = this.config.selectors;
 
-    this.$content = $(_selectors.feedContent);
-    this.$activities = $(_selectors.activities);
-    this.$messages = $(_selectors.messages);
-    this.$messagesResponsiveMenuItem = $(_selectors.messagesResponsiveMenuItem);
+    this.$el = $(this.config.el);
 
-    this.$unreadFeedIndicator = $(_selectors.unreadFeedNumber);
-    this.$unreadActivitiesIndicator = $(_selectors.unreadActivitiesNumber);
-    this.$unreadMessagesIndicator = $(_selectors.unreadMessagesNumber);
-
-    this.$flyoutTrigger = $(_selectors.flyoutTrigger);
-    this.$flyout = $(_selectors.flyout);
-
-    this.$tabsContent = $(_selectors.tabsContent);
-
-    this.$footer = $(_selectors.footer);
-
-    this.$body = $("body");
-
-    this.currentActivities = [];
-    this.highlightedActivitiesNumber = 0;
-    this.contentHeight;
-
-    this.init();
+    this.$el.length && this.init();
   }
 
-  // ------------------------------------------------------------------------------
-  // Initialise
-  // ------------------------------------------------------------------------------
-
   UserFeed.prototype.init = function() {
-    this._tabsInstance = new Tabs({ selector: _selectors.feedContent });
+    this._isFirstRun = true;
 
-    this._fetchFeed();
-  };
-
-  // -------------------------------------------------------------------------
-  // Private Functions
-  // -------------------------------------------------------------------------
-
-  UserFeed.prototype._responsifyTabsContentHeight = function() {
-    var _this = this,
-        contentOffset, windowHeight;
-
-    this.$flyoutTrigger.on("mouseenter", function() {
-
-      if (!_this.contentHeight) { // init hover listeners
-        _this.$flyout
-          .on("mouseenter", function() {
-            _this.$body.addClass("js-no-scroll");
-            _this._toggleBodyScroll();
-          })
-          .on("mouseleave", function() {
-            _this.$body.removeClass("js-no-scroll");
-            _this._toggleBodyScroll();
-          });
-
-        _this.contentHeight = _this.$tabsContent.height(); //set initial content height
-      }
-
-      contentOffset = _this.$tabsContent.offset().top - $(window).scrollTop();
-      windowHeight = $(window).height() - 20; // leaving 20px for margin
-      _this.$tabsContent.css("max-height", windowHeight - contentOffset);
+    this.tabs = new Tabs({ selector: this.$el });
+    this.flyout = new Flyout({ resizeTarget: this.tabs.$container });
+    this.content = new Content({ context: this.$el });
+    this.unreadCounter = new UnreadCounter();
+    this.popups = new Popups();
+    this.fetcher = new Fetcher({
+      ajax: {
+        url: this.config.ajaxUrl,
+        success: this._handleUpdate.bind(this)
+      },
+      onPause: this._handleFetcherState.bind(this)
     });
   };
 
-  UserFeed.prototype._toggleBodyScroll = function() {
-    if (this.$body.hasClass("js-no-scroll")) {
-      this.$body.on("scroll touchmove mousewheel", function(e) {
-        e.preventDefault();
-        e.stopPropagation();
-      });
+  //---------------------------------------------------------------------------
+  // Private functions
+  //---------------------------------------------------------------------------
+
+  UserFeed.prototype._handleUpdate = function(data) {
+    this._showPopups = this._canPopup(data.popupsMode);
+
+    this.content.update(data);
+    this.unreadCounter.update(this.content.messages.unreadCount);
+
+    if (this._showPopups && !this._isFirstRun) {
+      this.popups.jumpOut(this.content.getLatest());
     } else {
-      this.$body.off("scroll touchmove mousewheel");
-    }
-  };
-
-  UserFeed.prototype._bindLinks = function() {
-    var _this = this;
-
-    this.$content.find(_selectors.feedItem).off("click").on("click", function() {
-      _this._goToUrl($(this).find(_selectors.targetLink).attr("href"));
-    });
-  };
-
-  UserFeed.prototype._goToUrl = function(url) {
-    window.location.href = url;
-  };
-
-  UserFeed.prototype._updateUnreadMessagesResponsiveIndicator = function(unreadMessagesCount) {
-    if ((unreadMessagesCount > 0) && (!$(_selectors.unreadMessagesResponsiveNumber).length)) {
-      this.$messagesResponsiveMenuItem.children().last()
-          .append(
-            "<span class=" + _selectors.unreadMessagesResponsiveNumber.substr(1) +
-            "> (" + unreadMessagesCount + ")</span>"
-          );
-    }
-  };
-
-  UserFeed.prototype._updateUnreadFeedIndicator = function(newFeedItemsNumber) {
-    if (newFeedItemsNumber > 0) {
-      this.$unreadFeedIndicator.text(newFeedItemsNumber).removeClass("is-hidden");
-    } else {
-      this.$unreadFeedIndicator.addClass("is-hidden");
-    }
-  };
-
-  UserFeed.prototype._createUserActivities = function(feedActivities) {
-    var _this = this,
-      activitiesHtml = "",
-      i = 0;
-
-    // Concatenate activities
-    while ((i < feedActivities.length) && (i < this.config.maxFeedActivities)) {
-      activitiesHtml += feedActivities[i].text;
-      i++;
+      this._isFirstRun = false;
     }
 
-    // Update activities list
-    this.$activities.html(activitiesHtml);
-
-    // Bind target links to whole item
-    this._bindLinks();
-
-    // Highlight new activities
-    this.$activities
-      .children()
-      .slice(0, _this.highlightedActivitiesNumber)
-      .addClass("is-highlighted");
-
-    // Update new activities number
-    if (_this.highlightedActivitiesNumber > 0) {
-      this.$unreadActivitiesIndicator.text("(" + _this.highlightedActivitiesNumber + ")");
-    }
+    this._handleFetcherState();
   };
 
-  UserFeed.prototype._createUserMessages = function(feedMessages, newMessagesNumber) {
-    var messagesHtml = "",
-      i = 0;
-
-    // Concatenate messages
-    while ((i < feedMessages.length) && (i < this.config.maxFeedActivities)) {
-      if (!feedMessages[i]["read?"]) {
-        // Add highlight class if message has unread flag
-        messagesHtml += $(feedMessages[i].text).addClass("is-highlighted")[0].outerHTML;
-      } else {
-        messagesHtml += feedMessages[i].text;
-      }
-      i++;
-    }
-
-    // Update messages list
-    this.$messages.find("li").not(":last").remove();
-    this.$messages.prepend(messagesHtml);
-    this.$footer.removeClass("is-hidden");
-
-    // Bind target links to whole item
-    this._bindLinks();
-
-    // Update new messages number
-    if (newMessagesNumber > 0) {
-      this.$unreadMessagesIndicator.text("(" + newMessagesNumber + ")");
-    }
+  UserFeed.prototype._handleFetcherState = function() {
+    this.fetcher.pause = this._showPopups ? false : this._isMobile();
   };
 
-  UserFeed.prototype._getActivityNumber = function(feed) {
-    if (!feed.activities) { return; }
+  UserFeed.prototype._canPopup = function(mode) {
+    var state = false;
 
-    var newActivitiesCount = 0,
-      i = 0;
-
-    for (i; i < feed.activities.length; i++) {
-      this._isNewActivity(feed.activities[i].timestamp) && newActivitiesCount++;
+    if (window.lp.userFeed && window.lp.userFeed.popups &&
+        ((mode === 1 && !this._isMobile()) || mode === 2)) {
+      state = true;
     }
 
-    return newActivitiesCount;
+    return state;
   };
 
-  UserFeed.prototype._isNewActivity = function(timestamp) {
-    for (var j = 0; j < this.currentActivities.length; j++) {
-      if ( timestamp == this.currentActivities[j].timestamp ) {
-        return false;
-      }
-    }
-    return true;
-  };
-
-  UserFeed.prototype._updateActivities = function(feed) {
-    if (this.currentActivities.length) {
-      var newActivitiesNumber = this._getActivityNumber(feed);
-
-      if (this.highlightedActivitiesNumber < newActivitiesNumber) {
-        this.highlightedActivitiesNumber = newActivitiesNumber;
-      }
-
-      newActivitiesNumber && this._createUserActivities(feed.activities);
-
-    } else {
-      // Create activities list
-      feed.activities && feed.activities.length && this._createUserActivities(feed.activities);
-      this.currentActivities = feed.activities;
-    }
-  };
-
-  UserFeed.prototype._updateMessages = function(feed) {
-    var newMessagesNumber = feed.unreadMessagesCount;
-
-    feed.messages && feed.messages.length && this._createUserMessages(feed.messages, newMessagesNumber);
-    this._updateUnreadFeedIndicator(this.highlightedActivitiesNumber + newMessagesNumber);
-  };
-
-  UserFeed.prototype._updateFeed = function(clientWidth, fetchedFeed) {
-    if (!fetchedFeed) { return false; }
-
-    // Poll for wide screens
-    if (clientWidth >= 980) {
-      this._updateActivities(fetchedFeed);
-      this._updateMessages(fetchedFeed);
-      this._timeagoInstance = new TimeAgo({ context: _selectors.feedContent });
-      this._responsifyTabsContentHeight();
-
-      setTimeout(this._fetchFeed.bind(this), this.config.fetchInterval);
-    }
-    // Update for small & medium screens where this component is not visible
-    this._updateUnreadMessagesResponsiveIndicator(fetchedFeed.unreadMessagesCount);
-  };
-
-  UserFeed.prototype._fetchFeed = function() {
-    $.ajax({
-      url: this.config.feedUrl,
-      cache: false,
-      jsonpCallback: "lpUserFeedCallback",
-      dataType: "jsonp",
-      success: this._updateFeed.bind(this, document.documentElement.clientWidth),
-      error: this._updateFeed.bind(this, document.documentElement.clientWidth)
-    });
+  UserFeed.prototype._isMobile = function() {
+    return window.innerWidth < 980;
   };
 
   return UserFeed;
-
 });

--- a/app/assets/javascripts/lib/core/user_feed/content.js
+++ b/app/assets/javascripts/lib/core/user_feed/content.js
@@ -1,0 +1,81 @@
+//-----------------------------------------------------------------------------
+//
+// User Feed: Content
+//
+//-----------------------------------------------------------------------------
+
+define([
+  "jquery",
+  "lib/core/timeago",
+  "./content/activities",
+  "./content/messages",
+], function($, Timeago, Activities, Messages) {
+
+  "use strict";
+
+  var defaults = {
+    item:     ".js-user-feed__item",
+    itemLink: ".js-user-feed__item__link"
+  };
+
+  function Content(args) {
+    this.config = $.extend({}, defaults, args);
+
+    this.$context = $(this.config.context);
+
+    this.init();
+  }
+
+  Content.prototype.init = function() {
+    this.activities = new Activities({ item: this.config.item });
+    this.messages = new Messages();
+
+    this.listen();
+  };
+
+  //---------------------------------------------------------------------------
+  // Functions
+  //---------------------------------------------------------------------------
+
+  Content.prototype.update = function(data) {
+    this.activities.update(data);
+    this.messages.update(data);
+    this.timeago = new Timeago({ context: this.$context });
+  };
+
+  Content.prototype.getLatest = function() {
+    var $activities = this._getLatestByType("activities"),
+        $messages = this._getLatestByType("messages");
+
+    return $activities.add($messages);
+  };
+
+  //---------------------------------------------------------------------------
+  // Subscribe to events
+  //---------------------------------------------------------------------------
+
+  Content.prototype.listen = function() {
+    $(document).on("click", this.config.item, this._handleClick.bind(this));
+  };
+
+  //---------------------------------------------------------------------------
+  // Private functions
+  //---------------------------------------------------------------------------
+
+  Content.prototype._handleClick = function(event) {
+    var $target = $(event.target),
+        targetUrl = $target.find(this.config.itemLink).attr("href");
+
+    window.location.href = targetUrl;
+  };
+
+  Content.prototype._getLatestByType = function(type) {
+    var latestCount = this[type].latestCount;
+
+    return this[type].$container
+      .find(this.config.item)
+      .slice(0, latestCount);
+  };
+
+  return Content;
+});

--- a/app/assets/javascripts/lib/core/user_feed/content/_shared.js
+++ b/app/assets/javascripts/lib/core/user_feed/content/_shared.js
@@ -1,0 +1,103 @@
+//-----------------------------------------------------------------------------
+//
+// User Feed: Content: Activities & Messages shared functions
+//
+//-----------------------------------------------------------------------------
+
+define([], function() {
+
+  "use strict";
+
+  var shared = function() {
+
+    this._handleUpdate = function(itemsArray, onRender, unreadCount) {
+      var newHtml = this._getHtml(itemsArray),
+          doRender = this._hasNewContent(newHtml);
+
+      this.latestCount = this._getLatestCount(itemsArray);
+
+      if (unreadCount === undefined) {
+        this.unreadCount = this._getUnreadCount(itemsArray);
+      } else {
+        this.unreadCount = unreadCount;
+      }
+
+      if (doRender) {
+        this._renderItems(newHtml);
+        this._renderCounters();
+        onRender();
+      }
+    };
+
+    this._getHtml = function(itemsArray) {
+      var html = "", i, l = itemsArray.length;
+
+      for (i = 0; i < l; i++) {
+        html += itemsArray[i].text;
+      }
+
+      return html;
+    };
+
+    this._hasNewContent = function(html) {
+      var hasNew = this.currentHtml != html;
+
+      hasNew && (this.currentHtml = html);
+
+      return hasNew;
+    };
+
+    this._renderItems = function(html) {
+      this.$container.html(html);
+    };
+
+    this._renderCounters = function() {
+      var count = this.unreadCount,
+          counterText = count > 0 ? " (" + count + ")" : "";
+
+      // This updates all standalone & appended counters,
+      // e.g. "(3)", "Messages (3)"
+      this.$unreadCounters.text(function(index, oldText) {
+        var titleEnd = oldText.lastIndexOf("("), newText;
+
+        newText = oldText
+          .slice(0, titleEnd > -1 ? titleEnd : oldText.length)
+          .trim().concat(counterText).trim();
+
+        return newText;
+      });
+    };
+
+    this._getTimestamps = function(itemsArray) {
+      var timestamps = [], i = 0, l = itemsArray.length;
+
+      for (i = 0; i < l; i++) {
+        timestamps.push(new Date(itemsArray[i].timestamp).getTime());
+      }
+
+      return timestamps;
+    };
+
+    this._getLatestCount = function(itemsArray) {
+      var latestCount = 0;
+
+      if (this._lastTimestamp) {
+        var newTimestamps = this._getTimestamps(itemsArray),
+            i = 0;
+
+        while (newTimestamps[i] > this._lastTimestamp) {
+          latestCount++; i++;
+        }
+
+        this._lastTimestamp = newTimestamps[0];
+
+      } else {
+        this._lastTimestamp = new Date(itemsArray[0].timestamp).getTime();
+      }
+
+      return latestCount;
+    };
+  };
+
+  return shared;
+});

--- a/app/assets/javascripts/lib/core/user_feed/content/activities.js
+++ b/app/assets/javascripts/lib/core/user_feed/content/activities.js
@@ -1,0 +1,72 @@
+//-----------------------------------------------------------------------------
+//
+// User Feed: Content: Activities
+//
+//-----------------------------------------------------------------------------
+
+define([ "jquery", "./_shared" ], function($, shared) {
+
+  "use strict";
+
+  var defaults = {
+    container:     ".js-user-feed__activities",
+    unreadCounter: ".js-user-feed__activities__unread-counter"
+  };
+
+  function Activities(args) {
+    this.config = $.extend({}, defaults, args);
+
+    this.$container = $(this.config.container);
+    this.$unreadCounters = $(this.config.unreadCounter);
+
+    this.unreadCount = 0;
+  }
+
+  //---------------------------------------------------------------------------
+  // Mixins
+  //---------------------------------------------------------------------------
+
+  shared.call(Activities.prototype);
+
+  //---------------------------------------------------------------------------
+  // Functions
+  //---------------------------------------------------------------------------
+
+  Activities.prototype.update = function(data) {
+    var itemsArray = data.activities || [];
+
+    if (itemsArray.length) {
+      this._handleUpdate(itemsArray, this._markUnread.bind(this));
+    }
+  };
+
+  //---------------------------------------------------------------------------
+  // Private functions
+  //---------------------------------------------------------------------------
+
+  Activities.prototype._getUnreadCount = function(itemsArray) {
+    var unreadCount = 0;
+
+    if (this._lastReadTimestamp) {
+      var newTimestamps = this._getTimestamps(itemsArray),
+          i, l = newTimestamps.length;
+
+      for (i = 0; i < l; i++) {
+        (newTimestamps[i] > this._lastReadTimestamp) && unreadCount++;
+      }
+
+    } else {
+      this._lastReadTimestamp = new Date(itemsArray[0].timestamp).getTime();
+    }
+
+    return unreadCount;
+  };
+
+  Activities.prototype._markUnread = function() {
+    var $items = this.$container.find(this.config.item);
+
+    $items.slice(0, this.unreadCount).addClass("is-unread");
+  };
+
+  return Activities;
+});

--- a/app/assets/javascripts/lib/core/user_feed/content/messages.js
+++ b/app/assets/javascripts/lib/core/user_feed/content/messages.js
@@ -1,0 +1,62 @@
+//-----------------------------------------------------------------------------
+//
+// User Feed: Content: Messages
+//
+//-----------------------------------------------------------------------------
+
+define([ "jquery", "./_shared" ], function($, shared) {
+
+  "use strict";
+
+  var defaults = {
+    container:     ".js-user-feed__messages",
+    unreadCounter: ".js-user-feed__messages__unread-counter",
+    footer:        ".js-user-feed__messages__footer"
+  };
+
+  function Messages(args) {
+    this.config = $.extend({}, defaults, args);
+
+    this.$container = $(this.config.container);
+    this.$unreadCounters = $(this.config.unreadCounter);
+    this.$footer = $(this.config.footer);
+
+    this.unreadCount = 0;
+    this.isFirstRun = true;
+  }
+
+  //---------------------------------------------------------------------------
+  // Mixins
+  //---------------------------------------------------------------------------
+
+  shared.call(Messages.prototype);
+
+  //---------------------------------------------------------------------------
+  // Functions
+  //---------------------------------------------------------------------------
+
+  Messages.prototype.update = function(data) {
+    var itemsArray = data.messages || [];
+
+    if (itemsArray.length) {
+      this._handleUpdate(
+        itemsArray,
+        this._updateFooter.bind(this, !!itemsArray.length),
+        data.unreadMessagesCount
+      );
+    }
+  };
+
+  //---------------------------------------------------------------------------
+  // Private functions
+  //---------------------------------------------------------------------------
+
+  Messages.prototype._updateFooter = function(state) {
+    var $footer = this.$footer;
+
+    !$footer.closest("html").length && this.$container.append($footer);
+    $footer.toggleClass("is-hidden", !state);
+  };
+
+  return Messages;
+});

--- a/app/assets/javascripts/lib/core/user_feed/fetcher.js
+++ b/app/assets/javascripts/lib/core/user_feed/fetcher.js
@@ -1,0 +1,48 @@
+//-----------------------------------------------------------------------------
+//
+// User Feed: Fetcher
+//
+//-----------------------------------------------------------------------------
+
+define([ "jquery" ], function($) {
+
+  "use strict";
+
+  var defaults = {
+    ajax: {
+      url:           "https://www.lonelyplanet.com/thorntree/users/feed",
+      dataType:      "jsonp",
+      jsonpCallback: "lpUserFeedCallback",
+      cache:         false
+    },
+    interval: 15000
+  };
+
+  function Fetcher(args) {
+    this.config = $.extend(true, defaults, args);
+
+    this.init();
+  }
+
+  Fetcher.prototype.init = function() {
+    this._handleFetch();
+    this.cycle = setInterval(
+      this._handleFetch.bind(this),
+      this.config.interval
+    );
+  };
+
+  //---------------------------------------------------------------------------
+  // Private functions
+  //---------------------------------------------------------------------------
+
+  Fetcher.prototype._handleFetch = function() {
+    this.pause ? this.config.onPause() : this._fetch();
+  };
+
+  Fetcher.prototype._fetch = function() {
+    $.ajax(this.config.ajax);
+  };
+
+  return Fetcher;
+});

--- a/app/assets/javascripts/lib/core/user_feed/flyout.js
+++ b/app/assets/javascripts/lib/core/user_feed/flyout.js
@@ -1,0 +1,52 @@
+//-----------------------------------------------------------------------------
+//
+// User Feed: Flyout
+//
+//-----------------------------------------------------------------------------
+
+define([ "jquery" ], function($) {
+
+  "use strict";
+
+  var defaults = {
+    trigger: ".js-user-signed-in"
+  };
+
+  function Flyout(args) {
+    this.config = $.extend({}, defaults, args);
+
+    this.$trigger = $(this.config.trigger);
+    this.$resizeTarget = $(this.config.resizeTarget);
+
+    this.init();
+  }
+
+  Flyout.prototype.init = function() {
+    this.listen();
+  };
+
+  //---------------------------------------------------------------------------
+  // Subscribe to events
+  //---------------------------------------------------------------------------
+
+  Flyout.prototype.listen = function() {
+    this.$trigger.on("mouseenter", this._adaptHeight.bind(this));
+  };
+
+  //---------------------------------------------------------------------------
+  // Private functions
+  //---------------------------------------------------------------------------
+
+  Flyout.prototype._adaptHeight = function() {
+    var $target = this.$resizeTarget,
+        targetHeight = $target.height(),
+        topOffset = $target.offset().top,
+        windowHeight = window.innerHeight,
+        doShrink = (windowHeight - (targetHeight + topOffset)) < 21,
+        maxHeight = doShrink ? (windowHeight - topOffset - 20) : "100%";
+
+    $target.css("max-height", maxHeight);
+  };
+
+  return Flyout;
+});

--- a/app/assets/javascripts/lib/core/user_feed/popups.js
+++ b/app/assets/javascripts/lib/core/user_feed/popups.js
@@ -1,0 +1,137 @@
+//-----------------------------------------------------------------------------
+//
+// User Feed: Popups
+//
+//-----------------------------------------------------------------------------
+
+define([ "jquery" ], function($) {
+
+  "use strict";
+
+  var defaults = {
+    context: "#js-row--content",
+    templates: {
+      el: "<ul class='user-feed__list user-feed__popup'></ul>",
+      close: "<span class='user-feed__popup__close icon icon--cross'></span>"
+    },
+    timers: {
+      renderDelay: 100,
+      removeDelay: 500, // depends on hide css animation duration
+      ttl: 14000
+    }
+  };
+
+  function Popups(args) {
+    this.config = $.extend({}, defaults, args);
+
+    this.$context = $(this.config.context);
+
+    this.$context && this.init();
+  }
+
+  Popups.prototype.init = function() {
+    this.$el = $(this.config.templates.el);
+    this.$close = $(this.config.templates.close);
+
+    this.selector = "." + this.$el.attr("class").replace(" ", ".");
+
+    this.listen();
+  };
+
+  //---------------------------------------------------------------------------
+  // Subscribe to events
+  //---------------------------------------------------------------------------
+
+  Popups.prototype.listen = function() {
+    this.$context
+      .on("click", this.$close, this._handleCloseClick.bind(this));
+  };
+
+  //---------------------------------------------------------------------------
+  // Functions
+  //---------------------------------------------------------------------------
+
+  Popups.prototype.jumpOut = function($collection) {
+    if ($collection.length) {
+      this._index = 0;
+
+      this._renderInterval = setInterval(
+        this._handleRender.bind(this, $collection),
+        this.config.timers.renderDelay
+      );
+    }
+  };
+
+  //---------------------------------------------------------------------------
+  // Private functions
+  //---------------------------------------------------------------------------
+
+  Popups.prototype._handleCloseClick = function(event) {
+    var $popup = $(event.target).closest(this.selector);
+
+    this._handleClose($popup);
+  };
+
+  Popups.prototype._handleClose = function($popup) {
+    this._hide($popup);
+    setTimeout(
+      this._remove.bind(this, $popup),
+      this.config.timers.removeDelay
+    );
+  };
+
+  Popups.prototype._handleRender = function($collection) {
+    var $item = $collection.eq(this._index),
+        $popup = this.$el.html($item.clone()).clone();
+
+    this._render($popup);
+    this._stack();
+    setTimeout(
+      this._handleClose.bind(this, $popup),
+      this.config.timers.ttl
+    );
+
+    this._index++;
+
+    if (this._index == $collection.length) {
+      clearInterval(this._renderInterval);
+    }
+  };
+
+  Popups.prototype._render = function($popup) {
+    $popup
+      .append(this.config.templates.close)
+      .appendTo(this.$context);
+  };
+
+  Popups.prototype._hide = function($popup) {
+    $popup.css("opacity", "0");
+  };
+
+  Popups.prototype._remove = function($popup) {
+    $popup.remove();
+    this._stack();
+  };
+
+  Popups.prototype._stack = function() {
+    var $popups = $(this.selector),
+        $popup = $popups.last(),
+        height = $popup.height(),
+        clearance = 15, bottomMargin = 15,
+        offset, posY, i, l = $popups.length;
+
+    offset = parseInt($popup.css("bottom"));
+    posY = offset - bottomMargin;
+
+    for (i = 0; i < l; i++) {
+      $popup = $popups.eq(-i - 1);
+      height = $popup.height();
+
+      $popup.css("transform", "translate(0," + posY + "px)");
+
+      posY = posY - height - clearance;
+    }
+  };
+
+  return Popups;
+});

--- a/app/assets/javascripts/lib/core/user_feed/unread_counter.js
+++ b/app/assets/javascripts/lib/core/user_feed/unread_counter.js
@@ -1,0 +1,30 @@
+//-----------------------------------------------------------------------------
+//
+// User Feed: Unread Counter
+//
+//-----------------------------------------------------------------------------
+
+define([ "jquery" ], function($) {
+
+  "use strict";
+
+  var defaults = {
+    el:  ".js-user-feed__unread-counter",
+  };
+
+  function UnreadCounter(args) {
+    this.config = $.extend({}, defaults, args);
+
+    this.$el = $(this.config.el);
+  }
+
+  //---------------------------------------------------------------------------
+  // Functions
+  //---------------------------------------------------------------------------
+
+  UnreadCounter.prototype.update = function(unreadCount) {
+    this.$el.text(unreadCount).toggleClass("is-hidden", !unreadCount);
+  };
+
+  return UnreadCounter;
+});

--- a/app/assets/stylesheets/core/layouts/modern/_responsive_nav.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_responsive_nav.sass
@@ -38,8 +38,10 @@ $responsive-nav-width: 240px
       box-shadow: none
 
 .nav--offscreen__title
+  @extend %truncate-text
   +font-size(20)
   +vertically-center(50)
+  max-width: 160px
   vertical-align: top
   color: white
   font-weight: bold

--- a/app/assets/stylesheets/core/layouts/modern/_user_feed.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_user_feed.sass
@@ -4,7 +4,7 @@
 //
 // ----------------------------------------------------------------------------
 
-.user-feed,
+.user-feed
   left: -200px
   cursor: default
   width: 360px
@@ -51,7 +51,7 @@
   .ie8 &
     display: none
 
-.user-feed__content__unread-count
+.user-feed__content__unread-counter
   font-weight: normal
   color: $grey-highlight
 
@@ -61,6 +61,7 @@
   &.is-active
     display: block
   .activity-list__item
+    @extend %transition--base
     +font-size(14)
     position: relative
     margin: 0
@@ -68,7 +69,7 @@
     cursor: pointer
     font-weight: normal
     color: $titlegray
-    &.is-highlighted
+    &.is-unread
       background: mix($linkblue, #fff, 3%)
     &:hover
       background: mix($linkblue, #fff, 10%)
@@ -110,3 +111,44 @@
   padding: 30px 0
   text-align: center
   color: $lightgray
+
+.user-feed__popup
+  @extend %rounded-corners
+  @extend %transition--slower
+  @extend %fly-out-shadow
+  +z-layer(modal)
+  position: fixed
+  bottom: -150px
+  left: 0
+  display: block
+  box-sizing: border-box
+  border: 2px solid #297CBB
+  background: white
+  width: 94%
+  margin: 0 3%
+  transition-timing-function: cubic-bezier(.16,.3,.08,1.48)
+
+  +respond-to(wide-view)
+    left: 15px
+    width: 350px
+    margin: 0
+
+.user-feed__popup__close
+  @extend %transition--base
+  +size(20px)
+  position: absolute
+  top: -8px
+  right: -8px
+  border-radius: 50px
+  background-color: mix($red, white, 85%)
+  background-size: 12px
+  background-position: 4px -26px // because .icon--white is not accurate enough in this case
+  cursor: pointer
+
+  +respond-to(wide-view)
+    opacity: 0
+    .user-feed__popup:hover &
+      opacity: 1
+
+  &:hover
+    background-color: $red

--- a/app/data/layouts/user_nav.yml
+++ b/app/data/layouts/user_nav.yml
@@ -17,8 +17,7 @@
     -
       :title: "Messages"
       :slug: "https://www.lonelyplanet.com/thorntree/profiles/{{profileSlug}}/messages"
-      :icon_class: "icon--envelope--before icon--white--before"
-      :extra_class: "js-responsive-messages"
+      :icon_class: "icon--envelope--before icon--white--before js-user-feed__messages__unread-counter"
     -
       :title: "Forum Activity"
       :slug: "https://www.lonelyplanet.com/thorntree/profiles/{{profileSlug}}/activities"

--- a/app/views/templates/global-nav/_user_signed_in.html.haml
+++ b/app/views/templates/global-nav/_user_signed_in.html.haml
@@ -1,45 +1,44 @@
 .nav__item.nav__item--user.nav__submenu__trigger.js-user-signed-in
-  %img.nav__item--user-avatar.js-user-avatar{ data: { src: "{{avatar}}"} }
-  %span.notification-badge.notification-badge--unread-messages.wv--inline-block.is-hidden.js-unread-feed-count 0
+  %img.nav__item--user-avatar.js-user-avatar{ data: { src: "{{avatar}}"}, title: "", alt: "{{username}}" }
+  %span.notification-badge.notification-badge--unread-messages.wv--inline-block.js-user-feed__unread-counter.is-hidden
   %span.wv--hidden.nav--offscreen__title {{username}}
 
   .user-feed.nav__submenu.js-user-feed
-    .user-feed__container.nav--stacked.nav__submenu__content.icon--tapered-arrow-up--after.icon--white--after.icon--white--bordered
-      .user-feed__header.js-user-feed-header
+    .user-feed__container.nav--stacked.nav__submenu__content.icon--tapered-arrow-up--after.icon--white--after.icon--white--bordered{ title: ""}
+      .user-feed__header
         .user-feed__username {{username}}
         .user-feed__email {{email}}
         .user-feed__buttons
-          %a.split--right.icon--settings.icon--body-grey.js-user-settings{ href: "https://www.lonelyplanet.com/thorntree/forums/settings"}
+          %a.split--right.icon--settings.icon--body-grey{ href: "https://www.lonelyplanet.com/thorntree/forums/settings", title: "Forum settings"}
 
           .grid-wrapper--10
 
             .col--one-half
-              %a.btn.btn--linkblue.btn--small.btn--full-width.js-user-profile{ href: "https://www.lonelyplanet.com/thorntree/profiles/{{profileSlug}}"} View Profile
+              %a.btn.btn--linkblue.btn--small.btn--full-width{ href: "https://www.lonelyplanet.com/thorntree/profiles/{{profileSlug}}"} View Profile
             
             .col--one-half
-              %a.btn.btn--linkblue.btn--small.btn--outline.btn--full-width.js-user-sign_out{ href: "https://auth.lonelyplanet.com/users/sign_out"} Sign Out
+              %a.btn.btn--linkblue.btn--small.btn--outline.btn--full-width{ href: "https://auth.lonelyplanet.com/users/sign_out"} Sign Out
 
-      .user-feed__content.js-user-feed-content
+      .user-feed__content
         .nav__tabs
           .grid-wrapper--0
             .col--one-half
-              %a.btn.btn--large.btn--white.nav__tabs__btn.js-tab-trigger.is-active{ href: "#js-user-feed-activities-list"}
+              %a.btn.btn--large.btn--white.nav__tabs__btn.js-tab-trigger.is-active{ href: "#user-feed-activities"}
                 Recent activity
-                %span.user-feed__content__unread-count.js-unread-activities-count
+                %span.user-feed__content__unread-counter.js-user-feed__activities__unread-counter
               
             .col--one-half
-              %a.btn.btn--large.btn--white.nav__tabs__btn.js-tab-trigger{ href: "#js-user-feed-messages-list"}
+              %a.btn.btn--large.btn--white.nav__tabs__btn.js-tab-trigger{ href: "#user-feed-messages"}
                 Messages
-                %span.user-feed__content__unread-count.js-unread-messages-count
+                %span.user-feed__content__unread-counter.js-user-feed__messages__unread-counter
 
         .nav__tabs__content.js-tabs-content
-          %ul.user-feed__list.is-active#js-user-feed-activities-list
+          %ul#user-feed-activities.user-feed__list.js-user-feed__activities.is-active
             %li.activity-list__item--empty You have no recent activity.
 
-          %ul.user-feed__list#js-user-feed-messages-list
+          %ul#user-feed-messages.user-feed__list.js-user-feed__messages
             %li.activity-list__item--empty You have no private messages.
-
-            %li.user-feed__footer.user-feed__buttons.js-user-feed-footer.is-hidden
+            %li.user-feed__footer.user-feed__buttons.js-user-feed__messages__footer.is-hidden
               %a.btn.btn--linkblue.btn--full-width{ href: "https://www.lonelyplanet.com/thorntree/profiles/{{profileSlug}}/messages"} See all messages
             
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "grunt-contrib-connect": "latest",
     "grunt-contrib-copy": "latest",
     "grunt-contrib-jasmine": "0.8.x",
+    "jasmine-ajax": "3.x",
     "grunt-contrib-jshint": "latest",
     "grunt-contrib-watch": "latest",
     "grunt-grunticon": "latest",

--- a/spec/javascripts/fixtures/user_feed.html
+++ b/spec/javascripts/fixtures/user_feed.html
@@ -1,28 +1,193 @@
-<div class="js-unread-feed-count is-hidden"></div>
-<div class="js-user-signed-in"></div>
+<!-- User Feed flyout -->
+<div class="js-user-signed-in">
 
-<div class="js-user-feed">
+  <div class="js-user-feed__unread-counter is-hidden"></div>
 
-  <div class="js-user-feed-content">
-    <span class="js-unread-activities-count"></span>
-    <span class="js-unread-messages-count"></span>
-    
+  <div class="js-user-feed">
+
+    <a class="js-tab-trigger is-active" href="#user-feed-activities">
+      Recent activity <span class="js-user-feed__activities__unread-counter"></span>
+    </a>
+
+    <a class="js-tab-trigger" href="#user-feed-messages">
+      Messages <span class="js-user-feed__messages__unread-counter"></span>
+    </a>
+
     <div class="js-tabs-content">
 
-      <ul id="js-user-feed-activities-list">
-        <li class="js-user-feed-item">
-          <a class="js-user-feed-item-target-link" href="bar/foo">link</a>
-        </li>
+      <ul id="#user-feed-activities" class="js-user-feed__activities is-active">
+        <li>No activities</li>
       </ul>
 
-      <ul id="js-user-feed-messages-list">
-        <li class="js-user-feed-footer is-hidden">footer</li>
+      <ul id="#user-feed-messages" class="js-user-feed__messages">
+        <li>No messages</li>
+        <li class="js-user-feed__messages__footer is-hidden">
+          See all messages
+        </li>
       </ul>
 
     </div>
   </div>
 </div>
 
-<div class="js-responsive-messages">
+<!-- Messages menu item in mobile side nav -->
+<div class="js-user-feed__messages__unread-counter">
   <span>Messages</span>
 </div>
+
+<!-- Popups context-->
+<div id="js-row--content"></div>
+
+<!-- Sample responses -->
+<script id="sample-response-1" type="application/json">
+  {
+    "activities":[
+      {
+        "timestamp":"2015-01-05T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      },
+      {
+        "timestamp":"2015-01-04T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      },
+      {
+        "timestamp":"2015-01-03T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      },
+      {
+        "timestamp":"2015-01-02T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      },
+      {
+        "timestamp":"2015-01-01T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      }
+    ],
+    "messages":[
+      {
+        "timestamp":"2015-01-05T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item is-unread'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      },
+      {
+        "timestamp":"2015-01-04T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item is-unread'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      },
+      {
+        "timestamp":"2015-01-03T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item is-unread'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      },
+      {
+        "timestamp":"2015-01-02T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      },
+      {
+        "timestamp":"2015-01-01T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      }
+    ],
+    "unreadMessagesCount": 3,
+    "popupsMode": 2
+  }
+</script>
+
+<script id="sample-response-2" type="application/json">
+  {
+    "activities":[
+      {
+        "timestamp":"2015-01-07T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Bar</a></li>"
+      },
+      {
+        "timestamp":"2015-01-06T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Bar</a></li>"
+      },
+      {
+        "timestamp":"2015-01-03T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      },
+      {
+        "timestamp":"2015-01-02T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      },
+      {
+        "timestamp":"2015-01-01T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      }
+    ],
+    "messages":[
+      {
+        "timestamp":"2015-01-06T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item is-unread'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      },
+      {
+        "timestamp":"2015-01-05T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item is-unread'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      },
+      {
+        "timestamp":"2015-01-04T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item is-unread'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      },
+      {
+        "timestamp":"2015-01-03T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item is-unread'><a class='js-user-feed__item__link' href='/foo'>Bar</a></li>"
+      },
+      {
+        "timestamp":"2015-01-02T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      }
+    ],
+    "unreadMessagesCount": 4,
+    "popupsMode": 2    
+  }
+</script>
+
+<script id="sample-response-3" type="application/json">
+  {
+    "activities":[
+      {
+        "timestamp":"2015-01-08T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Bar</a></li>"
+      },
+      {
+        "timestamp":"2015-01-07T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Bar</a></li>"
+      },
+      {
+        "timestamp":"2015-01-06T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Bar</a></li>"
+      },
+      {
+        "timestamp":"2015-01-03T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      },
+      {
+        "timestamp":"2015-01-02T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      }
+    ],
+    "messages":[
+      {
+        "timestamp":"2015-01-07T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item is-unread'><a class='js-user-feed__item__link' href='/foo'>Bar</a></li>"
+      },
+      {
+        "timestamp":"2015-01-06T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item is-unread'><a class='js-user-feed__item__link' href='/foo'>Bar</a></li>"
+      },
+      {
+        "timestamp":"2015-01-05T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item is-unread'><a class='js-user-feed__item__link' href='/foo'>Bar</a></li>"
+      },
+      {
+        "timestamp":"2015-01-04T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item is-unread'><a class='js-user-feed__item__link' href='/foo'>Foo</a></li>"
+      },
+      {
+        "timestamp":"2015-01-03T00:00:00.000Z",
+        "text":"<li class='js-user-feed__item is-unread'><a class='js-user-feed__item__link' href='/foo'>Bar</a></li>"
+      }
+    ],
+    "unreadMessagesCount": 5,
+    "popupsMode": 2    
+  }
+</script>

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -12,4 +12,7 @@ window.lp = {
   },
   isMobile: false,
   getCookie: function() {},
+  userFeed: {
+    popups: false
+  }
 };


### PR DESCRIPTION
**This PR is mainly for the "Your Feed Popups" feature.** 

The feature was requested by TT users, so it's disabled by default in all other apps. To enable it, you need to add `window.lp.userFeed.popups = true` property to your app.
All the other display settings are managed through TT [forum settings](https://www.lonelyplanet.com/thorntree/forums/settings) (will be available after [this](https://github.com/lonelyplanet/community/pull/2414) gets merged).

`Desktop`

![user feed popups 2](https://cloud.githubusercontent.com/assets/1451471/10166124/eb32c066-66c2-11e5-9c69-8b812a2aef11.gif)

`Mobile` (popup is full width and the close button is always visible)

![user feed popups mobile](https://cloud.githubusercontent.com/assets/1451471/10166007/50d5c0cc-66c2-11e5-84d8-14c3f3f2b2f4.gif)

**Note:**
Feed is fetched each 15 seconds, so it's extremely unlikely to get more than 1-2 notifications at once. Just wanted to show dat cool stacking animation :]