### PR TITLE
configure_js should merge objects instead overwriting.

### DIFF
--- a/app/helpers/js_helper.rb
+++ b/app/helpers/js_helper.rb
@@ -48,7 +48,9 @@ module JsHelper
   def js_closure(opts, &blk)
     config = yield blk
     keys = config.configurations.keys
-    output = keys.reduce("#{config.root_namespace} = #{config.root_namespace} || {};") {|out, k| "#{out} #{k} = #{config.configurations[k].to_json};"}
+
+    output = 'function extend(a,b){a=a||{};for(var c in b)"object"==typeof b[c]?a[c]=extend(a[c],b[c]):a[c]=b[c];return a}'
+    output << keys.reduce("#{config.root_namespace} = #{config.root_namespace} || {};") {|out, k| "#{out} extend(#{k}, #{config.configurations[k].to_json});"}
     javascript_tag output
   end
 

--- a/spec/helpers/js_helper_spec.rb
+++ b/spec/helpers/js_helper_spec.rb
@@ -44,7 +44,7 @@ describe JsHelper do
       helper.configure_js('foo', {:bar=>'bizz'})
       helper.configure_js('bot', {:lot=>'op'})
       helper.js_configuration.should match(/script/)
-      helper.js_configuration.should eq "<script>\n//<![CDATA[\nwindow.lp = window.lp || {}; window.lp.foo = {\"bar\":\"bizz\"}; window.lp.bot = {\"lot\":\"op\"};\n//]]>\n</script>"
+      helper.js_configuration.should eq "<script>\n//<![CDATA[\nfunction extend(a,b){a=a||{};for(var c in b)\"object\"==typeof b[c]?a[c]=extend(a[c],b[c]):a[c]=b[c];return a}window.lp = window.lp || {}; extend(window.lp.foo, {\"bar\":\"bizz\"}); extend(window.lp.bot, {\"lot\":\"op\"});\n//]]>\n</script>"
     end
 
   end


### PR DESCRIPTION
real source of `extend` function used (uglified in the source):

```
function extend (target, source) {
  target = target || {};
  for (var prop in source) {
    if (typeof source[prop] === 'object') {
      target[prop] = extend(target[prop], source[prop]);
    } else {
      target[prop] = source[prop];
    }
  }
  return target;
}
```