### PR TITLE
Apply Fixes to BetaHelper

### DIFF
--- a/app/helpers/beta_helper.rb
+++ b/app/helpers/beta_helper.rb
@@ -2,7 +2,9 @@
 module BetaHelper
   # Look for a place presenter from Waldorf
   def place?
-    presenter.is_a?(PlacePresenter) if defined?(presenter)
+    return false unless place_presenter_defined?
+    return false unless respond_to? :presenter
+    presenter.is_a?(PlacePresenter)
   end
   alias_method :is_place?, :place?
 
@@ -16,5 +18,11 @@ module BetaHelper
     # Uncomment this for production launch
     # prng = Random.new(Time.now.to_i)
     # prng.rand < 0.0025
+  end
+
+  private
+
+  def place_presenter_defined?
+    defined? PlacePresenter
   end
 end

--- a/spec/helpers/beta_helper_spec.rb
+++ b/spec/helpers/beta_helper_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe BetaHelper do
+  PlacePresenter = Class.new unless defined? PlacePresenter
+
+  let(:klass) { Class.new.instance_eval { include BetaHelper } }
+  let(:instance) { klass.new }
+
+  describe '#show_beta_banner' do
+    let(:params) { Hash.new }
+    before { allow(instance).to receive(:params).and_return(params) } 
+    subject { instance.show_beta_banner }
+
+    context 'when params are empty' do
+      it { expect(subject).to eq false } 
+    end
+
+    context 'when params has beta key AND it is "destinations-next"' do
+      let(:params) { { beta: 'destinations-next' } }
+      it { expect(subject).to eq 1.0 }
+    end
+  end
+
+  describe '#place?' do
+    subject { instance.place? }
+
+    context 'when PlacePresenter is not defined' do
+      before { allow(instance).to receive(:place_presenter_defined?).and_return(false) }
+      it { expect(subject).to be false }
+    end
+
+    context 'considering the presnter' do
+      before { allow(instance).to receive(:place_presenter_defined?).and_return(true) }
+
+      context 'when there is no presenter' do
+        it { expect(subject).to eq false }
+      end
+
+      context 'when there is a presetner' do
+        before { allow(instance).to receive(:presenter).and_return(presenter) }
+
+        context 'when the presnter is an instance of PlacePresenter' do
+          let(:presenter) { double is_a?: true }
+          it { expect(subject).to eq true }
+        end
+
+        context 'when the presenter is not an instance of PlacePresenter' do
+          let(:presenter) { double is_a?: false }
+          it { expect(subject).to eq false }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rizzo was not correctly working on `Hotels` after it was bumped to
the latest version of Rizzo.  The error was an unitialized constant
of PlacePresenter because Hotels lacks such a presenter.  This
insulates that condition and wraps the module with tests to prevent
further problems.