### PR TITLE
Fix merge js

### DIFF
--- a/app/assets/javascripts/lib/core/user_feed/content.js
+++ b/app/assets/javascripts/lib/core/user_feed/content.js
@@ -74,7 +74,8 @@ define([
 
     return this[type].$container
       .find(this.config.item)
-      .slice(0, latestCount);
+      .slice(0, latestCount)
+      .not(".is-author");
   };
 
   return Content;

--- a/app/helpers/js_helper.rb
+++ b/app/helpers/js_helper.rb
@@ -48,7 +48,8 @@ module JsHelper
   def js_closure(opts, &blk)
     config = yield blk
     keys = config.configurations.keys
-    output = keys.reduce("#{config.root_namespace} = #{config.root_namespace} || {};") {|out, k| "#{out} #{k} = #{config.configurations[k].to_json};"}
+    output = 'function extend(a,b){a=a||{};for(var c in b)b[c].constructor==Array?a[c]=b[c]:"object"==typeof b[c]&&b[c].constructor!=Array?a[c]=extend(a[c],b[c]):a[c]=b[c];return a}'
+    output << keys.reduce("#{config.root_namespace} = #{config.root_namespace} || {};") {|out, k| "#{out} #{k}=#{k}||{}; extend(#{k}, #{config.configurations[k].to_json});"}
     javascript_tag output
   end
 

--- a/app/helpers/js_helper.rb
+++ b/app/helpers/js_helper.rb
@@ -48,7 +48,7 @@ module JsHelper
   def js_closure(opts, &blk)
     config = yield blk
     keys = config.configurations.keys
-    output = 'function extend(a,b){a=a||{};for(var c in b)b[c].constructor==Array?a[c]=b[c]:"object"==typeof b[c]&&b[c].constructor!=Array?a[c]=extend(a[c],b[c]):a[c]=b[c];return a}'
+    output = 'function extend(a,b){a=a||{};for(var c in b)"object"==typeof b[c]&&null!==b[c]&&b[c].constructor==Array?a[c]=b[c]:"object"==typeof b[c]?a[c]=extend(a[c],b[c]):a[c]=b[c];return a}'
     output << keys.reduce("#{config.root_namespace} = #{config.root_namespace} || {};") {|out, k| "#{out} #{k}=#{k}||{}; extend(#{k}, #{config.configurations[k].to_json});"}
     javascript_tag output
   end

--- a/spec/helpers/js_helper_spec.rb
+++ b/spec/helpers/js_helper_spec.rb
@@ -44,7 +44,7 @@ describe JsHelper do
       helper.configure_js('foo', {:bar=>'bizz'})
       helper.configure_js('bot', {:lot=>'op'})
       helper.js_configuration.should match(/script/)
-      helper.js_configuration.should eq "<script>\n//<![CDATA[\nwindow.lp = window.lp || {}; window.lp.foo = {\"bar\":\"bizz\"}; window.lp.bot = {\"lot\":\"op\"};\n//]]>\n</script>"
+      helper.js_configuration.should eq "<script>\n//<![CDATA[\nfunction extend(a,b){a=a||{};for(var c in b)\"object\"==typeof b[c]&&null!==b[c]&&b[c].constructor==Array?a[c]=b[c]:\"object\"==typeof b[c]?a[c]=extend(a[c],b[c]):a[c]=b[c];return a}window.lp = window.lp || {}; window.lp.foo=window.lp.foo||{}; extend(window.lp.foo, {\"bar\":\"bizz\"}); window.lp.bot=window.lp.bot||{}; extend(window.lp.bot, {\"lot\":\"op\"});\n//]]>\n</script>"
     end
 
   end

--- a/spec/javascripts/fixtures/user_feed.html
+++ b/spec/javascripts/fixtures/user_feed.html
@@ -95,7 +95,7 @@
     "activities":[
       {
         "timestamp":"2015-01-07T00:00:00.000Z",
-        "text":"<li class='js-user-feed__item'><a class='js-user-feed__item__link' href='/foo'>Bar</a></li>"
+        "text":"<li class='js-user-feed__item is-author'><a class='js-user-feed__item__link' href='/foo'>Bar</a></li>"
       },
       {
         "timestamp":"2015-01-06T00:00:00.000Z",

--- a/spec/javascripts/lib/core/user_feed_spec.js
+++ b/spec/javascripts/lib/core/user_feed_spec.js
@@ -178,14 +178,16 @@ define([
               expect(unreadCounter.$el).toHaveText("4");
             });
 
-            it("shows popups for new items", function() {
+            it("shows popups for new items that are not self-activity", function() {
               jasmine.clock().tick(3 * popupTimers.renderDelay + 1);
-              expect($(popups.selector)).toHaveLength(3);
+              // Waits for three new but pops only two.
+              // One of three is own-activity.
+              expect($(popups.selector)).toHaveLength(2);
             });
 
             it("adds close button to each popup", function() {
               jasmine.clock().tick(3 * popupTimers.renderDelay + 1);
-              expect($("." + popups.$close.attr("class").split(" ")[0])).toHaveLength(3);
+              expect($("." + popups.$close.attr("class").split(" ")[0])).toHaveLength(2);
             });
 
             it("removes popups after defined time", function() {


### PR DESCRIPTION
full source of `extend`:

```
function extend (target, source) {
  target = target || {};
  for (var prop in source) {
    if((typeof source[prop] === 'object') && source[prop] !== null && source[prop].constructor == Array){
      target[prop] = source[prop];
    } else if (typeof source[prop] === 'object') {
      target[prop] = extend(target[prop], source[prop]);
    } else {
      target[prop] = source[prop];
    }
  }
  return target;
}
```

handles arrays and null values properly.

Also define namespace key if it's empty before merging. So when merge happens the key is always present.