### PR TITLE
Bring back old timeago requirejs alias

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,7 +162,7 @@ module.exports = function(grunt) {
                 hogan: "./vendor/assets/javascripts/hogan/dist/hogan-3.0.0.amd",
                 jplugs: "./vendor/assets/javascripts/jquery-plugins",
                 jquery: "./vendor/assets/javascripts/jquery/dist/jquery",
-                jqueryTimeago: "./vendor/assets/javascripts/jquery-timeago/jquery.timeago",
+                jtimeago: "./vendor/assets/javascripts/jquery-timeago/jquery.timeago",
                 sailthru: "./vendor/assets/javascripts/sailthru/v1",
                 sCode: "./vendor/assets/javascripts/omniture/s_code",
                 trackjs: "./vendor/assets/javascripts/trackjs/trackjs",

--- a/app/assets/javascripts/lib/core/timeago.js
+++ b/app/assets/javascripts/lib/core/timeago.js
@@ -7,7 +7,7 @@
 define([
   "jquery",
   "lib/utils/debounce",
-  "jqueryTimeago"
+  "jtimeago"
 ], function($, debounce) {
 
   "use strict";

--- a/app/views/layouts/partials/inline_js/_require_js_config.html.haml
+++ b/app/views/layouts/partials/inline_js/_require_js_config.html.haml
@@ -7,7 +7,7 @@
       hogan: "hogan/dist/hogan-3.0.0.amd",
       jplugs: "jquery-plugins",
       jquery:  "jquery/dist/jquery",
-      jqueryTimeago: "jquery-timeago/jquery.timeago",
+      jtimeago: "jquery-timeago/jquery.timeago",
       sailthru: "sailthru/v1",
       sCode: "omniture/s_code",
       trackjs: "trackjs/trackjs",

--- a/config/requirejs.yml
+++ b/config/requirejs.yml
@@ -3,7 +3,7 @@ paths:
   hogan: "hogan/dist/hogan-3.0.0.amd"
   jplugs: "jquery-plugins"
   jquery: "jquery/dist/jquery"
-  jqueryTimeago: "jquery-timeago/jquery.timeago"
+  jtimeago: "jquery-timeago/jquery.timeago"
   sailthru: "sailthru/v1"
   sCode: "omniture/s_code"
   trackjs: "trackjs/trackjs"


### PR DESCRIPTION
This prevents the necessity of updating requirejs config in each app.