### PR TITLE
Fix the wrong value of 'narrow-view' variable in documentation

### DIFF
--- a/app/assets/stylesheets/sass/mixins/_responsive.sass
+++ b/app/assets/stylesheets/sass/mixins/_responsive.sass
@@ -6,7 +6,7 @@
 // Always use this mixin to apply breakpoints so we can support legacy browsers.
 //
 // You can pass in named arguments or integers.
-// Named argument options are: narrow-view (360px), medium-view (600px),
+// Named argument options are: narrow-view (380px), medium-view (600px),
 // wide-view(980) larger-than-ipad(1025px) and cinema-view(1100).
 //
 // Example of use: http://sassmeister.com/gist/8047633.


### PR DESCRIPTION
Proper `narrow-view` breakpoint value is `380px`