### PR TITLE
Fix for squashed MPU card on mobile

### DIFF
--- a/app/assets/stylesheets/core/core_components/cards/_variations.sass
+++ b/app/assets/stylesheets/core/core_components/cards/_variations.sass
@@ -100,6 +100,7 @@
       content: normal !important
 
 .card--sponsored--mpu
+  padding-top: 100%
   .card__content
     width: 300px
     padding: 0


### PR DESCRIPTION
This fixes issue when MPU card got squashed on devices with viewport width lower than 380px. 
JIRA ticket: https://lonelyplanet.atlassian.net/browse/LPMC-269

**Before**
![Before image](http://i.imgur.com/RjTPy03.png)

**After**
![After image](http://i.imgur.com/d5CahOr.png)

This doesn't affect the cards behaviour on larger screens.

![Nexus 7 screenshot](http://i.imgur.com/Ac4JwKS.png)