### PR TITLE
Treat submenus of global navigation items as click-trackable.

### DIFF
--- a/app/views/components/navigation/_nav_item.html.haml
+++ b/app/views/components/navigation/_nav_item.html.haml
@@ -13,8 +13,12 @@
   show_badge = defined?(submenu_item) && item[:badge]
   item_analytics = item.fetch(:analytics, {})
 
+  if (defined?(global) && defined?(has_submenu))
+    item[:submenu].each { |item| item[:global] = true }
+  end
+
   lpa_data = case
-             when defined?(global)
+             when defined?(global) && global
                item_analytics.merge lpa: { category: "Global Navigation Click", action: item[:title] }
              else
                item_analytics

--- a/app/views/components/navigation/_submenu.html.haml
+++ b/app/views/components/navigation/_submenu.html.haml
@@ -2,7 +2,7 @@
   .nav--stacked.nav__submenu__content.js-submenu.icon--tapered-arrow-up--after.icon--white--after
     - if item
       - item[:submenu].each do |sub|
-        = render "components/navigation/nav_item", item: sub, active: false, submenu_item: true
+        = render "components/navigation/nav_item", item: sub, active: false, submenu_item: true, global: sub[:global]
 
     - if defined?(button_text) && button_text
       .nav__submenu__button

--- a/app/views/layouts/partials/inline_js/_nativo.html
+++ b/app/views/layouts/partials/inline_js/_nativo.html
@@ -1,1 +1,1 @@
-<script type="text/javascript" src="//a.postrelease.com/serve/load.js?async=true"></script>
+<script async type="text/javascript" src="//a.postrelease.com/serve/load.js?async=true"></script>


### PR DESCRIPTION
This one ads `data-lpa-` tracking attributes to submenus of core navigation items. Previously only primary nav items were taken into account. 

Pix for reference:

![](https://jumpshare.com/v/fOsUBvWU8epaWyOpzpmL+/Zrzut+ekranu+2015-11-19+o+15.08.33.png)