### PR TITLE
Remove ads in tests

### DIFF
--- a/app/helpers/js_helper.rb
+++ b/app/helpers/js_helper.rb
@@ -35,6 +35,9 @@ module JsHelper
   def configure_js(namespace, config)
     # source url
     @js_config ||= Config.new(LP_DEFAULT_JS_NAMESPACE)
+
+    # Stop ads from loading in tests
+    config = {} if namespace == :ads && Rails.env.test?
     @js_config.add(namespace, config)
   end
 


### PR DESCRIPTION
Since we pass `ad_config`'s from all over the site to this single method, this might be the one place we can test for ads and decide to not show them in the context of acceptance tests. I sure hope so at least...