### PR TITLE
Remove async attribute

### DIFF
--- a/app/views/layouts/partials/inline_js/_nativo.html
+++ b/app/views/layouts/partials/inline_js/_nativo.html
@@ -1,1 +1,1 @@
-<script async type="text/javascript" src="//a.postrelease.com/serve/load.js?async=true"></script>
+<script type="text/javascript" src="//a.postrelease.com/serve/load.js?async=true"></script>


### PR DESCRIPTION
As of 6 days ago when we put `async` on this, something odd started happening and a bunch of errors started randomly appearing...

![](http://d.pr/i/1exyW+)

I think what's happening is the Nativo script is also using a `umd` module for jQuery. When it loads async, it sometimes overwrites our own jquery and they happen to use a version of jQuery that does not support the `.wrap` method for whatever reason. Not to mention it's `2.1.1`.

Let's remove the async and see if the errors drop off.