### PR TITLE
Make sure presenters are defined before using them in BetaHelper

### DIFF
--- a/app/helpers/beta_helper.rb
+++ b/app/helpers/beta_helper.rb
@@ -4,7 +4,9 @@ module BetaHelper
   def place_or_article?
     return false unless place_presenter_defined?
     return false unless respond_to? :presenter
-    presenter.is_a?(PlacePresenter) || presenter.is_a?(ArticlesShowPresenter)
+    return true if defined?(::PlacePresenter) && presenter.is_a?(::PlacePresenter)
+    return true if defined?(::ArticlesShowPresenter) && presenter.is_a?(::ArticlesShowPresenter)
+    false
   end
   alias_method :is_place_or_article?, :place_or_article?
 


### PR DESCRIPTION
This fixes case when an app that uses rizzo has no `PlacePresenter` and no `ArticlesShowPresenter` defined.