### PR TITLE
Tests for changes in history.state without using spies

### DIFF
--- a/spec/javascripts/lib/components/gallery_spec.js
+++ b/spec/javascripts/lib/components/gallery_spec.js
@@ -50,15 +50,21 @@ define([ "jquery", "public/assets/javascripts/lib/components/gallery.js" ], func
     });
 
     describe("Updating the history", function() {
-      var newSlug = "my-image";
+      var initialSlug = null,
+          newSlug = "my-image";
+
       beforeEach(function(){
-        spyOn(window.history, "pushState");
+        initialSlug = window.location.pathname;
         gallery._updateSlug(newSlug);
       });
 
       it("Updates the state", function() {
         var expectedSlug = $("#js-gallery").data("href") + "/" + newSlug;
-        expect(window.history.pushState).toHaveBeenCalledWith({  }, "", expectedSlug);
+        expect(window.location.pathname).toEqual(expectedSlug);
+      });
+
+      afterEach(function() {
+        window.history.replaceState({}, null, initialSlug)
       });
     });
 

--- a/spec/javascripts/lib/page/pushstate_spec.js
+++ b/spec/javascripts/lib/page/pushstate_spec.js
@@ -95,13 +95,20 @@ define([ "jquery", "public/assets/javascripts/lib/page/pushstate.js" ], function
     });
 
     describe("updating push state", function() {
+      var initialSlug = null;
+
       beforeEach(function() {
-        spyOn(history, "pushState");
+        initialSlug = window.location.pathname;
         window.pushstate = new Pushstate();
         pushstate.navigate("", "/test");
       });
-      it("history.pushState is called", function() {
-        expect(history.pushState).toHaveBeenCalledWith({}, null, "/test");
+
+      it("changes current location", function() {
+        expect(window.location.pathname).toEqual("/test");
+      });
+
+      afterEach(function() {
+        window.history.replaceState({}, null, initialSlug)
       });
     });
 


### PR DESCRIPTION
Change was forced after jasmine-core update to 2.4.0, more information: https://github.com/jasmine/jasmine/issues/948

----------------------
@WunderBart  @jcreamer898 can you take a look?

_I was also thinking about adding `expect(history.state).toEqual({});` but history.state is supported in phantomjs 2.0 and well it's additional thing to test. The most important is covered \o/_