### PR TITLE
Change flights widget's tracking event params

### DIFF
--- a/app/assets/javascripts/lib/analytics/flights.js
+++ b/app/assets/javascripts/lib/analytics/flights.js
@@ -19,16 +19,9 @@ define([ "jquery" ], function($) {
     }
 
     window.lp.analytics.api.trackEvent({
-      category: "flights",
-      action:   "search",
-      params: {
-        locationStart: this.$locationStart.val(),
-        locationEnd:   this.$locationEnd.val(),
-        startDate:     this.$startDate.val(),
-        endDate:       this.$endDate.val(),
-        travellers:    this.countTravellers(),
-        currency:      this.$currency.val()
-      }
+      category: "Partner",
+      label: "Click",
+      action: "partner:scyscanner.com|type:Flight|name:" + this.$locationEnd.val()
     });
 
   };


### PR DESCRIPTION
This is a tweak of params we send for tracking when user submits search form in Flights widget.