### PR TITLE
Switch label <-> action in event params for booking widgets

### DIFF
--- a/app/assets/javascripts/lib/analytics/flights.js
+++ b/app/assets/javascripts/lib/analytics/flights.js
@@ -20,8 +20,8 @@ define([ "jquery" ], function($) {
 
     window.lp.analytics.api.trackEvent({
       category: "Partner",
-      label: "Click",
-      action: "partner:scyscanner.com|type:Flight|name:" + this.$locationEnd.val()
+      action: "Click",
+      label:  "partner:scyscanner.com|type:Flight|name:" + this.$locationEnd.val()
     });
 
   };

--- a/app/assets/javascripts/lib/analytics/travel_insurance_omniture.js
+++ b/app/assets/javascripts/lib/analytics/travel_insurance_omniture.js
@@ -37,8 +37,8 @@ require([ "jquery", "lib/analytics/analytics" ], function($, Analytics) {
         if (!$(".js-travel-widget .input-validation-errors").length) {
           window.lp.analytics.api.trackEvent({
             category: "Partner",
-            label:    "Click",
-            action: [
+            action:    "Click",
+            label: [
               "partner:worldnomads",
               "type:Insurance",
               "name:" + destinations


### PR DESCRIPTION
So, there was an error in the spec that slipped into codebase. `action` you see here fellas should be `label`. Yeeup.