### PR TITLE
Add rizzo next to precompile, update to named AMD module

### DIFF
--- a/lib/rizzo/assets.rb
+++ b/lib/rizzo/assets.rb
@@ -28,7 +28,7 @@ module Rizzo::Assets
 
   def self.precompile_as_engine
     [
-      'rizzo-next',
+      'rizzo-next.css',
       'core.css',
       'core_ie.css',
       'core_fixed_width.css',

--- a/lib/rizzo/assets.rb
+++ b/lib/rizzo/assets.rb
@@ -5,6 +5,7 @@ module Rizzo::Assets
 
   def self.precompile
     [
+      'rizzo-next.css',
       'core.css',
       'core_ie.css',
       'core_fixed_width.css',
@@ -27,6 +28,7 @@ module Rizzo::Assets
 
   def self.precompile_as_engine
     [
+      'rizzo-next',
       'core.css',
       'core_ie.css',
       'core_fixed_width.css',

--- a/node_modules/rizzo-next/dist/rizzo-next.js
+++ b/node_modules/rizzo-next/dist/rizzo-next.js
@@ -1,14 +1,4 @@
-(function webpackUniversalModuleDefinition(root, factory) {
-	if(typeof exports === 'object' && typeof module === 'object')
-		module.exports = factory();
-	else if(typeof define === 'function' && define.amd)
-		define([], factory);
-	else {
-		var a = factory();
-		for(var i in a) (typeof exports === 'object' ? exports : root)[i] = a[i];
-	}
-})(this, function() {
-return /******/ (function(modules) { // webpackBootstrap
+define("rizzo-next", [], function() { return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
 
@@ -24496,6 +24486,4 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = exports["default"];
 
 /***/ }
-/******/ ])
-});
-;
+/******/ ])});;


### PR DESCRIPTION
Rizzo Next needed to be updated to be included as a named module so that it wouldn't break when it actually ran in the browser. Also needed to add rizzo-next.css to the precompile so it gets deployed to s3.