### PR TITLE
Manage url params in controller.js

### DIFF
--- a/app/assets/javascripts/lib/page/controller.js
+++ b/app/assets/javascripts/lib/page/controller.js
@@ -28,7 +28,7 @@ define([
 
   Controller.prototype.init  = function() {
     this.pushState = new PushState;
-    this._generateState(this.getDocumentRoot(), this.getParams());
+    this._generateState(this.getSlug(), this.getParams());
   };
 
   // Subscribe

--- a/app/assets/javascripts/lib/page/controller.js
+++ b/app/assets/javascripts/lib/page/controller.js
@@ -28,7 +28,7 @@ define([
 
   Controller.prototype.init  = function() {
     this.pushState = new PushState;
-    this._generateState(this.getSlug());
+    this._generateState(this.getDocumentRoot(), this.getParams());
   };
 
   // Subscribe
@@ -86,7 +86,7 @@ define([
 
     .on(":controller/back", function() {
       this._removeState();
-      this._generateState();
+      this._generateState(this.getDocumentRoot(), this.getParams());
       this.pushState.navigate(this._serializeState(), this._currentRoot());
     }.bind(this))
 
@@ -165,11 +165,11 @@ define([
   Controller.prototype._generateState = function(newDocumentRoot, newParams) {
     this.states || (this.states = []);
     this.currentState == null ? this.currentState = 0 : this.currentState += 1;
+
     this.states.push({
-      state: $.deparam(newParams || this.getParams()),
-      documentRoot: newDocumentRoot || this.getDocumentRoot()
+      state: $.deparam(newParams || ""),
+      documentRoot: newDocumentRoot || ""
     });
-    return this._removePageParam();
   };
 
   Controller.prototype._removeState = function() {

--- a/spec/javascripts/lib/page/controller_spec.js
+++ b/spec/javascripts/lib/page/controller_spec.js
@@ -86,7 +86,7 @@ define([
         expect(controller.states[controller.states.length - 1].state).toEqual(deserialized);
       });
 
-      it("updates the application state object empty object if paramseters are not provided", function() {
+      it("updates the application state object empty object if parameters are not provided", function() {
         controller._generateState("url", null);
         expect(controller.states[controller.states.length - 1].state).toEqual({});
       });

--- a/spec/javascripts/lib/page/controller_spec.js
+++ b/spec/javascripts/lib/page/controller_spec.js
@@ -81,9 +81,14 @@ define([
         spyOn(controller, "getParams").and.returnValue(serialized.urlParams);
       });
 
-      it("updates the application state object with the search parameters", function() {
-        controller._generateState();
+      it("updates the application state object with provided parameters", function() {
+        controller._generateState("url", controller.getParams());
         expect(controller.states[controller.states.length - 1].state).toEqual(deserialized);
+      });
+
+      it("updates the application state object empty object if paramseters are not provided", function() {
+        controller._generateState("url", null);
+        expect(controller.states[controller.states.length - 1].state).toEqual({});
       });
     });
 


### PR DESCRIPTION
PROBLEM: So far empty params have been ALWAYS overwritten by current window.location.search. Probably that was a reason of introducing removePageParam here: https://github.com/lonelyplanet/rizzo/commit/cf3e10ceb2464819d4848272186b2e20de0a7483. Because of this, after closing lightbox page param diseappeared(problem spotted in community) while an other params were added to lightbox url. SOLUTION: Every time some state is pushed to local variable in _generateState both: url and params are provided and empty params are not overwritten by params from window.location(so, we respect that in some cases params do not exist)