### PR TITLE
namespace fix; form action path fix

### DIFF
--- a/app/controllers/rizzo/sailthru_controller.rb
+++ b/app/controllers/rizzo/sailthru_controller.rb
@@ -1,7 +1,7 @@
 class Rizzo::SailthruController < ActionController::Base
 
   def save
-    render json: {}, status: SailthruService.register(form_params)
+    render json: {}, status: Rizzo::SailthruService.register(form_params)
   end
 
   private

--- a/app/controllers/rizzo/sailthru_controller.rb
+++ b/app/controllers/rizzo/sailthru_controller.rb
@@ -1,12 +1,14 @@
-class Rizzo::SailthruController < ActionController::Base
+module Rizzo
+  class SailthruController < ActionController::Base
 
-  def save
-    render json: {}, status: Rizzo::SailthruService.register(form_params)
-  end
+    def save
+      render json: {}, status: SailthruService.register(form_params)
+    end
 
-  private
+    private
 
-  def form_params
-    params.require(:sailthru)
+    def form_params
+      params.require(:sailthru)
+    end
   end
 end

--- a/app/lib/rizzo/sailthru_service.rb
+++ b/app/lib/rizzo/sailthru_service.rb
@@ -1,59 +1,61 @@
-class Rizzo::SailthruService
-  SAILTHRU_API_URL = ENV['RIZZO_SAILTHRU_API_URL'] || 'http://canary.community.lonelyplanet.com/'
-  REGISTER_OR_CHECK_URL = SAILTHRU_API_URL + "sailthru/v1/users"
-  SEND_EMAIL_URL = SAILTHRU_API_URL + "sailthru/v1/email"
-  SAILTHRU_REGIONS = YAML.load_file(Rizzo::Engine.root.join('app/data/sailthru/regions.yml'))
+module Rizzo
+  class SailthruService
+    SAILTHRU_API_URL = ENV['RIZZO_SAILTHRU_API_URL'] || 'http://canary.community.lonelyplanet.com/'
+    REGISTER_OR_CHECK_URL = SAILTHRU_API_URL + "sailthru/v1/users"
+    SEND_EMAIL_URL = SAILTHRU_API_URL + "sailthru/v1/email"
+    SAILTHRU_REGIONS = YAML.load_file(Rizzo::Engine.root.join('app/data/sailthru/regions.yml'))
 
-  def self.register(params)
-    return 409 if exists?(params[:email])
+    def self.register(params)
+      return 409 if exists?(params[:email])
 
-    status = create_or_update!(params)
+      status = create_or_update!(params)
 
-    if params[:email_template] && status == 200
-      send!(params[:email], params[:email_template])
+      if params[:email_template] && status == 200
+        send!(params[:email], params[:email_template])
+      end
+
+      status
     end
 
-    status
-  end
+    def self.exists?(email)
+      response = Typhoeus::Request.new(REGISTER_OR_CHECK_URL,
+        params: { email: email }
+      ).run
+      response.code == 200
+    end
 
-  def self.exists?(email)
-    response = Typhoeus::Request.new(REGISTER_OR_CHECK_URL,
-      params: { email: email }
-    ).run
-    response.code == 200
-  end
+    def self.create_or_update!(params)
+      return 400 if invalid?(params)
 
-  def self.create_or_update!(params)
-    return 400 if invalid?(params)
+      response = Typhoeus::Request.new(REGISTER_OR_CHECK_URL,
+        method: :put,
+        headers: { "Content-Type" => 'application/json' },
+        body: {
+          email: params[:email],
+          country: params[:country],
+          region: SAILTHRU_REGIONS[params[:country]],
+          lists: [params[:lists]],
+          source: params[:source],
+          vars: params[:vars]
+        }.to_json
+      ).run
+      response.code
+    end
 
-    response = Typhoeus::Request.new(REGISTER_OR_CHECK_URL,
-      method: :put,
-      headers: { "Content-Type" => 'application/json' },
-      body: {
-        email: params[:email],
-        country: params[:country],
-        region: SAILTHRU_REGIONS[params[:country]],
-        lists: [params[:lists]],
-        source: params[:source],
-        vars: params[:vars]
-      }.to_json
-    ).run
-    response.code
-  end
+    def self.send!(email, template)
+      Typhoeus::Request.new(SEND_EMAIL_URL,
+        method: :post,
+        params: {
+          email: email,
+          template: template
+        }
+      ).run
+    end
 
-  def self.send!(email, template)
-    Typhoeus::Request.new(SEND_EMAIL_URL,
-      method: :post,
-      params: {
-        email: email,
-        template: template
-      }
-    ).run
-  end
+    private
 
-  private
-
-  def self.invalid?(params)
-    params.values.any? { |param| param.blank? }
+    def self.invalid?(params)
+      params.values.any? { |param| param.blank? }
+    end
   end
 end

--- a/app/views/layouts/partials/snippets/_footer_sitemap.html.haml
+++ b/app/views/layouts/partials/snippets/_footer_sitemap.html.haml
@@ -12,7 +12,7 @@
         %strong
           20% discount
         on your next guidebook purchase
-      %form.newsletter-footer.js-newsletter-footer(action='//www.lonelyplanet.com/rizzo_sailthru' method='post')
+      %form.newsletter-footer.js-newsletter-footer(action='/rizzo_sailthru' method='post')
         %input{:type=>"hidden", :name=>"authenticity_token", :value=>form_authenticity_token.to_s}
         %label.polyfill--placeholder.newsletter-footer__placeholder Email
         %input.input--small--newsletter(type='text' id='newsletter-email' autocomplete='off' name='sailthru[email]' placeholder='your@email.com' required='required')


### PR DESCRIPTION
This change fixes `NameError (uninitialized constant Rizzo::SailthruController::SailthruService)`. Calling SailthruSevice from Rizzo::SailthruController was throwing NameError due to improper nesting (see. http://guides.rubyonrails.org/autoloading_and_reloading_constants.html#nesting). I decided to use module nesting convention instead and it fixed the problem.