### PR TITLE
Make global header match Rizzo Next

### DIFF
--- a/app/assets/stylesheets/core/layouts/modern/_primary_nav_new.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_primary_nav_new.sass
@@ -68,8 +68,9 @@ $lp-min-480: #{(480 * .0625)}em   // 30em
 $lp-min-360: #{(360 * .0625)}em   // 22.5em
 $lp-min-320: #{(320 * .0625)}em   // 20em
 
-$lp-max-720: #{(719 * .0625)}em // 44.9375em
-$lp-max-480: #{(479 * .0625)}em // 29.9375em
+$lp-max-1530: #{(1530 * .0625)}em // 95.625
+$lp-max-720: #{(719 * .0625)}em   // 44.9375em
+$lp-max-480: #{(479 * .0625)}em   // 29.9375em
 
 $lp-blue: #287bbb
 $lp-color-red: #dc221a
@@ -277,11 +278,17 @@ $lp-notification-badge-size: 17px
     top: (10rem * $scaling-factor)
     font-size: (1.8rem * $scaling-factor)
 
+    @media (max-width: $lp-max-1530)
+      right: 0
+
     &:before
       border: (.8rem * $scaling-factor) solid transparent
       border-bottom-color: #fff
       margin-left: (-.8rem * $scaling-factor)
       top: (-1.6rem * $scaling-factor)
+
+      @media (max-width: $lp-max-1530)
+        right: (1.6rem * $scaling-factor)
 
   .sub-navigation--visible
     box-shadow: 0 $lp-gutter (9rem * $scaling-factor) rgba(0, 0, 0, .4)

--- a/app/assets/stylesheets/core/layouts/modern/_primary_nav_new.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_primary_nav_new.sass
@@ -231,15 +231,10 @@ $lp-notification-badge-size: 17px
     &:not(:last-child)
       margin-right: (1.7rem * $scaling-factor)
 
-  .navigation__item--user > .navigation__link
-    border-width: 1px
-    border-radius: (1.7rem * $scaling-factor)
-    padding: (1.7rem * $scaling-factor) (2rem * $scaling-factor) (1.5rem * $scaling-factor)
-
   .navigation__link
     font-size: (1.4rem * $scaling-factor)
     text-decoration: none
-    transition: color 400ms ease-in-out
+    transition: color 400ms
 
     &:hover,
     &:active,
@@ -256,10 +251,19 @@ $lp-notification-badge-size: 17px
       color: #7796bb
 
   .navigation__item--user > .navigation__link
-    padding: (1.7rem * $scaling-factor) (2rem * $scaling-factor) (1.7rem * $scaling-factor)
+    border-color: rgba(#fff, .8)
+    border-width: 1px
+    border-radius: (1.7rem * $scaling-factor)
+    padding: (1.7rem * $scaling-factor) (2rem * $scaling-factor) (1.5rem * $scaling-factor)
+    transition: background-color 400ms, border-color 400ms
 
-  .navigation__item--user > a:hover
-    border-color: #fff
+    &:hover,
+    &:active,
+    &:focus
+      background-color: rgba(#fff, .07)
+      border-color: rgba(#fff, .38)
+      color: #fff
+      transition: background-color 400ms, border-color 400ms
 
 
 

--- a/app/assets/stylesheets/core/layouts/modern/_primary_nav_new.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_primary_nav_new.sass
@@ -72,28 +72,8 @@ $lp-max-720: #{(719 * .0625)}em // 44.9375em
 $lp-max-480: #{(479 * .0625)}em // 29.9375em
 
 $lp-blue: #287bbb
-
-@mixin lp-fade-edge($side: "right", $offset: 0, $width: 30px, $color: #fff)
-  background-image: linear-gradient(to left, $color 0%, rgba($color, 0) 100%)
-  bottom: 0
-  content: ""
-  height: 100%
-  position: absolute
-  #{$side}: #{$offset}
-  top: 0
-  width: $width
-
-@mixin lp-icon-before($uri)
-  &:before
-    background-image: url($uri)
-    background-position: center -94px
-    background-repeat: no-repeat
-    background-size: 50%
-    content: ""
-    display: block
-    height: 59px
-    position: relative
-    width: 82px
+$lp-color-red: #dc221a
+$lp-notification-badge-size: 17px
 
 %lp-icon-font
   font-family: "dest-next-icons"
@@ -151,7 +131,7 @@ $lp-blue: #287bbb
     width: (7.2rem * $scaling-factor)
 
     @media (min-width: $lp-min-720)
-      width: (15rem * $scaling-factor)
+      width: (14.2rem * $scaling-factor)
 
   .header__search
     color: #fff
@@ -170,7 +150,7 @@ $lp-blue: #287bbb
     &:active,
     &:focus
       [class*="icon-"]
-        margin-right: (($lp-gutter / 2) / 4) * 3
+        margin-right: ((1.2rem - .3) * $scaling-factor)
 
   .header__mobile
     right: ($lp-gutter / -2)
@@ -245,10 +225,10 @@ $lp-blue: #287bbb
     height: (13rem * $scaling-factor)
 
   .navigation__item
-    margin-left: (1rem * $scaling-factor)
+    margin-left: (1.7rem * $scaling-factor)
 
     &:not(:last-child)
-      margin-right: (4rem * $scaling-factor)
+      margin-right: (1.7rem * $scaling-factor)
 
   .navigation__item--user > .navigation__link
     border-width: 1px
@@ -293,7 +273,7 @@ $lp-blue: #287bbb
     box-sizing: inherit
     border-radius: (.2rem * $scaling-factor)
     width: (29rem * $scaling-factor)
-    margin-left: (-29rem / 2 * $scaling-factor)
+    margin-left: ((-29rem / 2 + .1) * $scaling-factor)
     top: (10rem * $scaling-factor)
     font-size: (1.8rem * $scaling-factor)
 
@@ -384,42 +364,109 @@ $lp-blue: #287bbb
 
   // ---------------------------------------------------------------------------
   // notification-badge
+  //
+  // All styles from Rizzo Next are being included below until this component
+  // is namespaced. Namespaced styles have been retained
+  //
+  // Pixel values are used for finer control and exact positioning, sizing
   // ---------------------------------------------------------------------------
 
-  // pixel values for finer control and exact positioning, sizing
   .notification-badge
+    width: $lp-notification-badge-size
+    height: $lp-notification-badge-size
+    font-size: 10px
+    font-weight: bold
+    font-style: normal
+    line-height: ($lp-notification-badge-size + 1)
+    text-align: center
+    color: #fff
+    border-radius: 50%
+    background-color: $lp-color-red
+    user-select: none
+
+  // override Rizzo
+  .notification-badge
+    box-sizing: border-box
+    box-shadow: none
+    left: auto
+
+
+  .notification-badge__wrap
+    position: relative
+
+  .notification-badge--shop
+    position: absolute
+    top: 46.5px
+    right: -6px
+
+  .notification-badge--shop-inline
+    position: absolute
+    left: 46px
+    top: 18px
+    width: 6px
+    height: 6px
+
+  .notification-badge--user,
+  .notification-badge--user-inline
+    position: absolute
+    border: 3px solid #fff
+
+  .notification-badge--user
+    top: 0
+    right: -2px
+    width: 15px
+    height: 15px
+
+  .notification-badge--user-inline
+    top: -5px
+    right: -11px
+    width: 12px
+    height: 12px
+
+  .notification-badge--mobile-menu
+    position: absolute
+    top: 16px
+    right: 12px
+    width: 6px
+    height: 6px
+    z-index: 2
+
+  // namespaced styles
+
+  // pixel values for finer control and exact positioning, sizing
+  .lp-notification-badge
     width: 17px
     height: 17px
     font-size: 10px
     line-height: 18px
 
   // pixel values for finer control and exact positioning, sizing
-  .notification-badge--user
-    right: -2px
-    width: 15px
-    height: 15px
-
-  // rem too small to work for dimensions
-  .notification-badge--user-inline
-    top: (-.5rem * $scaling-factor)
-    right: (-1.1rem * $scaling-factor)
-    width: 12px
-    height: 12px
-
-  // pixel values for finer control and exact positioning, sizing
-  .notification-badge--shop
+  .lp-notification-badge--shop
     top: 46.5px
     right: -6px
 
   // pixel values for finer control and exact positioning, sizing
-  .notification-badge--shop-inline
+  .lp-notification-badge--shop-inline
     left: 46px
     top: 18px
     width: 6px
     height: 6px
 
   // pixel values for finer control and exact positioning, sizing
-  .notification-badge--mobile-menu
+  .lp-notification-badge--user
+    right: -2px
+    width: 15px
+    height: 15px
+
+  // rem too small to work for dimensions
+  .lp-notification-badge--user-inline
+    top: (-.5rem * $scaling-factor)
+    right: (-1.1rem * $scaling-factor)
+    width: 12px
+    height: 12px
+
+  // pixel values for finer control and exact positioning, sizing
+  .lp-notification-badge--mobile-menu
     top: 16px
     right: 12px
     width: 6px
@@ -436,26 +483,26 @@ $lp-blue: #287bbb
 .mobile-navigation
   box-sizing: border-box
   font-family: "Benton Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif
-  padding: (3rem * $scaling-factor) !important
-  width: (25rem * $scaling-factor) !important
+  padding: (3rem * $scaling-factor)
+  width: (25rem * $scaling-factor)
 
 // Pixel values for more precise measurements
 .mobile-navigation__item
-  border-bottom-width: 1px !important
-  font-size: 18px !important
+  border-bottom-width: 1px
+  font-size: 18px
 
   .icon
-    width: (1.3rem * $scaling-factor) !important
-    height: (1.3rem * $scaling-factor) !important
-    margin-top: (.6rem * $scaling-factor) !important
+    width: (1.3rem * $scaling-factor)
+    height: (1.3rem * $scaling-factor)
+    margin-top: (.6rem * $scaling-factor)
 
 .mobile-navigation__link
   line-height: 1.5
-  padding: (1.6rem * $scaling-factor) 0 (1.1rem * $scaling-factor) !important
-  text-decoration: none !important
+  padding: (1.6rem * $scaling-factor) 0 (1.1rem * $scaling-factor)
+  text-decoration: none
 
 .mobile-navigation__item--active > .mobile-navigation__link
-  color: #333 !important
+  color: #333
 
 
 
@@ -469,48 +516,48 @@ $lp-blue: #287bbb
   box-sizing: border-box
 
 .mobile-sub-navigation .sub-navigation-feature
-  padding: 0 0 (2rem * $scaling-factor) !important
+  padding: 0 0 (2rem * $scaling-factor)
 
 // Pixel width because rem calculation is 1 px off
 .mobile-sub-navigation .sub-navigation-feature__image
-  margin-right: (1.4rem * $scaling-factor) !important
-  width: 60px !important
+  margin-right: (1.4rem * $scaling-factor)
+  width: 60px
 
 .mobile-sub-navigation .sub-navigation-feature__text
-  padding-top: (.8rem * $scaling-factor) !important
+  padding-top: (.8rem * $scaling-factor)
 
 .mobile-sub-navigation .sub-navigation-feature__title
-  font-size: (1.6rem * $scaling-factor) !important
+  font-size: (1.6rem * $scaling-factor)
 
 .mobile-sub-navigation .sub-navigation-feature__subtitle
-  font-size: (1.1rem * $scaling-factor) !important
-  margin-top: (.4rem * $scaling-factor) !important
+  font-size: (1.1rem * $scaling-factor)
+  margin-top: (.4rem * $scaling-factor)
 
 .mobile-sub-navigation .sub-navigation__list
-  padding: 0 !important
+  padding: 0
 
 .mobile-sub-navigation .sub-navigation__item
-  font-size: (1.6rem * $scaling-factor) !important
-  margin-left: 0 !important
-  margin-right: 0 !important
+  font-size: (1.6rem * $scaling-factor)
+  margin-left: 0
+  margin-right: 0
 
 .mobile-sub-navigation .sub-navigation__link
-  padding: (1rem * $scaling-factor) ($lp-gutter / 2) (.8rem * $scaling-factor) !important
+  padding: (1rem * $scaling-factor) ($lp-gutter / 2) (.8rem * $scaling-factor)
   text-decoration: none
 
   &:after
-    height: calc(100% + .2rem) !important
-    left: -$lp-gutter !important
-    right: -$lp-gutter !important
-    top: (-.1rem * $scaling-factor) !important
-    width: calc(100% + #{$lp-gutter} + #{$lp-gutter}) !important
+    height: calc(100% + .2rem)
+    left: -$lp-gutter
+    right: -$lp-gutter
+    top: (-.1rem * $scaling-factor)
+    width: calc(100% + #{$lp-gutter} + #{$lp-gutter})
 
 .mobile-sub-navigation .sub-navigation__button
-  font-size: (1.2rem * $scaling-factor) !important
-  padding: (1.8rem * $scaling-factor) (3rem * $scaling-factor) (1.4rem * $scaling-factor) !important
-  border-radius: 0 0 (.2rem * $scaling-factor) (.2rem * $scaling-factor) !important
-  padding-top: (2.3rem * $scaling-factor) !important
-  padding-bottom: (1.9rem * $scaling-factor) !important
+  font-size: (1.2rem * $scaling-factor)
+  padding: (1.8rem * $scaling-factor) (3rem * $scaling-factor) (1.4rem * $scaling-factor)
+  border-radius: 0 0 (.2rem * $scaling-factor) (.2rem * $scaling-factor)
+  padding-top: (2.3rem * $scaling-factor)
+  padding-bottom: (1.9rem * $scaling-factor)
 
 
 
@@ -525,7 +572,7 @@ $lp-blue: #287bbb
   font-family: "Benton Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif
 
   @media (min-width: $lp-min-720)
-    box-shadow: (-5rem * $scaling-factor) 0 (15rem * $scaling-factor) rgba(0, 0, 0, .5) !important
+    box-shadow: (-5rem * $scaling-factor) 0 (15rem * $scaling-factor) rgba(0, 0, 0, .5)
 
   [class^="icon-"],
   [class*=" icon-"]
@@ -537,118 +584,113 @@ $lp-blue: #287bbb
   .icon-chevron-right:before
     content: "\e603"
 
-.lp-search--visible
-  @media (min-width: $lp-min-720)
-    box-shadow: (.5rem * $scaling-factor) 0 (23rem * $scaling-factor) rgba(0, 0, 0, .5) !important
-
 .lp-search__container
-  max-width: (129rem * $scaling-factor) !important
-  margin-left: auto !important
-  margin-right: auto !important
+  max-width: (129rem * $scaling-factor)
+  margin-left: auto
+  margin-right: auto
 
   @media (max-width: $lp-max-480)
-    padding-left: ($lp-gutter / 2) !important
-    padding-right: ($lp-gutter / 2) !important
+    padding-left: ($lp-gutter / 2)
+    padding-right: ($lp-gutter / 2)
 
   @media (min-width: $lp-min-480)
-    margin-left: $lp-gutter !important
-    margin-right: $lp-gutter !important
+    margin-left: $lp-gutter
+    margin-right: $lp-gutter
 
   @media (min-width: $lp-min-1080)
-    margin-left: ($lp-gutter * 2) !important
-    margin-right: ($lp-gutter * 2) !important
+    margin-left: ($lp-gutter * 2)
+    margin-right: ($lp-gutter * 2)
 
   @media (min-width: $lp-min-1410)
-    margin-left: auto !important
-    margin-right: auto !important
+    margin-left: auto
+    margin-right: auto
 
 .lp-search__inner
-  height: (5rem * $scaling-factor) !important
-  line-height: (3.8rem * $scaling-factor) !important
+  height: (5rem * $scaling-factor)
+  line-height: (3.8rem * $scaling-factor)
 
   @media (min-width: $lp-min-720)
-    height: (13rem * $scaling-factor) !important
+    height: (13rem * $scaling-factor)
 
   &:after
     @media (max-width: $lp-max-720)
-      // +lp-fade-edge("right", 29px)
       background-image: linear-gradient(to left, #fff 0%, rgba(#fff, 0) 100%)
       bottom: 0
       content: ""
       height: 100%
       position: absolute
-      right: 29px !important
+      right: 29px
       top: 0
-      width: 30px !important
+      width: 30px
 
 .lp-search__label
-  width: (2rem * $scaling-factor) !important
-  height: (2rem * $scaling-factor) !important
+  width: (2rem * $scaling-factor)
+  height: (2rem * $scaling-factor)
 
   @media (min-width: $lp-min-720)
-    top: (-.4rem * $scaling-factor) !important
+    top: (-.4rem * $scaling-factor)
 
   &:before
-    font-size: (2rem * $scaling-factor) !important
+    font-size: (2rem * $scaling-factor)
 
 .lp-search__input
-  left: (2.5rem * $scaling-factor) !important
-  right: (5.9rem * $scaling-factor) !important
-  width: calc(100% - #{(5rem * $scaling-factor)} - #{(.9rem * $scaling-factor)}) !important
-  height: (3.8rem * $scaling-factor) !important
-  font-size: (1.6rem * $scaling-factor) !important
+  left: (2.5rem * $scaling-factor)
+  right: (5.9rem * $scaling-factor)
+  width: calc(100% - #{(5rem * $scaling-factor)} - #{(.9rem * $scaling-factor)})
+  height: (3.8rem * $scaling-factor)
+  font-size: (1.6rem * $scaling-factor)
 
   @media (max-width: $lp-max-720)
-    padding-top: (.3rem * $scaling-factor) !important
+    padding-top: (.3rem * $scaling-factor)
 
   @media (min-width: $lp-min-720)
-    left: (4rem * $scaling-factor) !important
-    right: (4rem * $scaling-factor) !important
-    font-size: (2.4rem * $scaling-factor) !important
-    padding-top: 1px !important
-    width: calc(100% - #{(8rem * $scaling-factor)}) !important
+    left: (3.4rem * $scaling-factor)
+    right: (3.4rem * $scaling-factor)
+    font-size: (2.4rem * $scaling-factor)
+    padding-top: 1px
+    width: calc(100% - #{(8rem * $scaling-factor)})
 
 .lp-search__close
-  width: (3.8rem * $scaling-factor) !important
-  height: (3.8rem * $scaling-factor) !important
-  right: (-.9rem * $scaling-factor) !important
+  width: (3.8rem * $scaling-factor)
+  height: (3.8rem * $scaling-factor)
+  right: (-.9rem * $scaling-factor)
 
   @media (min-width: $lp-min-720)
-    right: 0 !important
+    right: 0
 
   &:before
-    font-size: (1.8rem * $scaling-factor) !important
+    font-size: (1.8rem * $scaling-factor)
 
     @media (min-width: $lp-min-720)
-      font-size: (2rem * $scaling-factor) !important
+      font-size: (2rem * $scaling-factor)
 
 .lp-search-results
-  transform: translateY((-2rem * $scaling-factor)) !important
+  transform: translateY((-2rem * $scaling-factor))
 
 .lp-search-results--visible
-  transform: translateY(0) !important
+  transform: translateY(0)
 
 .lp-search-results__list
-  margin-bottom: ((4.5rem + .6rem) * $scaling-factor) !important
-  padding-top: (1rem * $scaling-factor) !important
-  border-top-width: 1px !important
+  margin-bottom: ((4.5rem + .6rem) * $scaling-factor)
+  padding-top: (1rem * $scaling-factor)
+  border-top-width: 1px
 
 // Pixel value for line-height so that it's more precise
 .lp-search-item
-  margin-bottom: (1rem * $scaling-factor) !important
-  line-height: 60px !important
+  margin-bottom: (1rem * $scaling-factor)
+  line-height: 60px
 
 .lp-search-item__link
-  padding-left: (11rem * $scaling-factor) !important
-  text-decoration: none !important
+  padding-left: (11rem * $scaling-factor)
+  text-decoration: none
 
 .lp-search-item__name
-  font-size: (1.8rem * $scaling-factor) !important
-  border-bottom-width: 1px !important
+  font-size: (1.8rem * $scaling-factor)
+  border-bottom-width: 1px
 
   @media (min-width: $lp-min-720)
-    font-size: (2.2rem * $scaling-factor) !important
-    transform: translateX(0) !important
+    font-size: (2.2rem * $scaling-factor)
+    transform: translateX(0)
 
 .lp-search-item:hover,
 .lp-search-item:active,
@@ -656,15 +698,15 @@ $lp-blue: #287bbb
 .lp-search-item--selected
   .lp-search-item__name
     @media (min-width: $lp-min-720)
-      transform: translateX(7px) !important
+      transform: translateX(7px)
 
 .lp-search-results__more
-  margin-bottom: (4.5rem * $scaling-factor) !important
-  font-size: (1.2rem * $scaling-factor) !important
+  margin-bottom: (4.5rem * $scaling-factor)
+  font-size: (1.2rem * $scaling-factor)
 
 .lp-search-results__more
   color: $lp-blue
-  text-decoration: none !important
+  text-decoration: none
 
   &:hover
   &:active,
@@ -672,12 +714,12 @@ $lp-blue: #287bbb
     color: $lp-blue + 30
 
   [class*="icon-"]
-    transform: translateX(6px) !important
+    transform: translateX(6px)
 
   &:hover [class*="icon-"],
   &:active [class*="icon-"],
   &:focus [class*="icon-"]
-    transform: translateX(2px) !important
+    transform: translateX(2px)
 
 
 
@@ -688,5 +730,5 @@ $lp-blue: #287bbb
 // ---------------------------------------------------------------------------
 
 .topic__image
-  height: (6rem * $scaling-factor) !important
-  width: (8rem * $scaling-factor) !important
+  height: (6rem * $scaling-factor)
+  width: (8rem * $scaling-factor)

--- a/app/assets/stylesheets/core/layouts/modern/_primary_nav_new.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_primary_nav_new.sass
@@ -1,239 +1,596 @@
-$scaling-factor: 0.7142857142857143
+// -----------------------------------------------------------------------------
+// Variables
+// -----------------------------------------------------------------------------
+
+// Rizzo Next base font size / Rizzo base font size
+$scaling-factor: (10 / 14)
+
+// Rizzo Next variables
+$lp-gutter: (3rem * $scaling-factor)
+
+$lp-min-1410: #{(1410 * .0625)}em // 88.125em
+$lp-min-1350: #{(1350 * .0625)}em // 84.375em
+$lp-min-1290: #{(1290 * .0625)}em // 80.625em
+$lp-min-1200: #{(1200 * .0625)}em // 75em
+$lp-min-1080: #{(1080 * .0625)}em // 67.5em
+$lp-min-1024: #{(1024 * .0625)}em // 64em
+$lp-min-960: #{(960 * .0625)}em   // 60em
+$lp-min-840: #{(840 * .0625)}em   // 52.5em
+$lp-min-768: #{(768 * .0625)}em   // 48em
+$lp-min-720: #{(720 * .0625)}em   // 45em
+$lp-min-600: #{(600 * .0625)}em   // 37.5em
+$lp-min-560: #{(560 * .0625)}em   // 35em
+$lp-min-480: #{(480 * .0625)}em   // 30em
+$lp-min-360: #{(360 * .0625)}em   // 22.5em
+$lp-min-320: #{(320 * .0625)}em   // 20em
+
+$lp-max-720: #{(719 * .0625)}em // 44.9375em
+$lp-max-480: #{(479 * .0625)}em // 29.9375em
+
+@mixin lp-fade-edge($side: "right", $offset: 0, $width: 30px, $color: #fff)
+  background-image: linear-gradient(to left, $color 0%, rgba($color, 0) 100%)
+  bottom: 0
+  content: ""
+  height: 100%
+  position: absolute
+  #{$side}: #{$offset}
+  top: 0
+  width: $width
+
+@mixin lp-icon-before($uri)
+  &:before
+    background-image: url($uri)
+    background-position: center -94px
+    background-repeat: no-repeat
+    background-size: 50%
+    content: ""
+    display: block
+    height: 59px
+    position: relative
+    width: 82px
 
 .content-wrapper.navigation-wrapper.rizzo-navigation.rizzo-next
+
+  // ---------------------------------------------------------------------------
+  // header
+  // ---------------------------------------------------------------------------
+
   .header
     background-color: $navblue
 
   .header__container
-    @media (min-width: 30em)
-      margin-left: (3rem * $scaling-factor)
-      margin-right: (3rem * $scaling-factor)
-    @media (min-width: 67.5em)
+    max-width: (129rem * $scaling-factor)
+    margin-left: auto
+    margin-right: auto
+
+    @media (max-width: $lp-max-480)
+      padding-left: ($lp-gutter / 2)
+      padding-right: ($lp-gutter / 2)
+
+    @media (min-width: $lp-min-480)
+      margin-left: $lp-gutter
+      margin-right: $lp-gutter
+
+    @media (min-width: $lp-min-1080)
       margin-left: (6rem * $scaling-factor)
       margin-right: (6rem * $scaling-factor)
-    @media (min-width: 88.125em)
+
+    @media (min-width: $lp-min-1410)
       margin-left: auto
       margin-right: auto
 
-  .header__logo
-    fill: white
-    @media (min-width: 45em)
-      width: (15rem * $scaling-factor)
-
   .header__inner
-    max-width: 1290px
-    margin: 0 auto
     border-bottom: 0
-    @media (min-width: 45em)
+    height: (5rem * $scaling-factor)
+
+    @media (min-width: $lp-min-720)
       height: (13rem * $scaling-factor)
 
+  .header__logo
+    fill: #fff
+    width: (7.2rem * $scaling-factor)
+
+    @media (min-width: $lp-min-720)
+      width: (15rem * $scaling-factor)
+
+  .header__search
+    color: #fff
+
+    @media (min-width: $lp-min-1080)
+      height: 100%
+      font-size: (2.4rem * $scaling-factor)
+      margin-top: (-6.5rem * $scaling-factor)
+      line-height: 100%
+
+  .header__search [class*="icon-"]
+    margin-right: (1.5rem * $scaling-factor)
+    font-size: (2rem * $scaling-factor)
+
+  .header__mobile
+    right: ($lp-gutter / -2)
+
+  .header__mobile--left
+    right: auto
+    left: ($lp-gutter / -2)
+
+  .header__mobile-search
+    width: (5rem * $scaling-factor)
+    height: (5rem * $scaling-factor)
+
+    &:before
+      margin-left: (.4rem * $scaling-factor)
+
+  .header__mobile-menu
+    height: (5rem * $scaling-factor)
+    width: (5rem * $scaling-factor)
+
+  // Pixel value for line-height to be more precise
+  .header__mobile-search,
+  .header__mobile-menu,
+  .header__mobile-cart
+    line-height: 50px
+
+    &:before
+      font-size: (2.3rem * $scaling-factor)
+
+  .header--narrow .header__mobile-search,
+  .header--narrow .header__mobile-menu,
+  .header--narrow .header__mobile-cart
+    color: #fff
+
+  .header__mobile-menu .menu-icon
+    top: (2.4rem * $scaling-factor)
+    left: ($lp-gutter / 2)
+    right: ($lp-gutter / 2)
+
+    &:before
+      top: (-.5rem * $scaling-factor)
+
+    &:after
+      top: (.5rem * $scaling-factor)
+
+  .header__mobile-menu .menu-icon,
+  .header__mobile-menu .menu-icon:before,
+  .header__mobile-menu .menu-icon:after
+    height: (.2rem * $scaling-factor)
+    background-color: #fff
+    width: (2rem * $scaling-factor)
+
+  .header--narrow .header__mobile-menu .menu-icon,
+  .header--narrow .header__mobile-menu .menu-icon:before,
+  .header--narrow .header__mobile-menu .menu-icon:after
+    background-color: #fff
+
+
+
+
+
+  // ---------------------------------------------------------------------------
+  // navigation
+  // ---------------------------------------------------------------------------
+
+  // pixel value here because rem calculation is 1 px off
   .navigation
-    line-height: (13rem * $scaling-factor)
+    line-height: 130px
 
   .navigation__item--active
+    border-bottom: 0
     height: (13rem * $scaling-factor)
 
   .navigation__item
     margin-left: (1rem * $scaling-factor)
+
     &:not(:last-child)
-      margin-right: 2.5rem //(4rem * $scaling-factor)
+      margin-right: (4rem * $scaling-factor)
+
+  .navigation__item--user > a
+    border-width: 1px
+    border-radius: (2.2rem * $scaling-factor)
+    padding: (1.7rem * $scaling-factor) (2rem * $scaling-factor)
 
   .navigation__link
-    color: white
-    font-size: 1.2rem
+    font-size: (1.4rem * $scaling-factor)
     text-decoration: none
-    &:hover
-      color: white
+    transition: color 400ms ease-in-out
 
+    &:hover,
+    &:active,
+    &:focus
+      transition: color 400ms
+
+  .navigation__link,
   .navigation__item--active .navigation__link
-    color: white
+    color: #fff
+
+    &:hover,
+    &:active,
+    &:focus
+      color: #7796bb
 
   .navigation__item--user > .navigation__link
     padding: (1.7rem * $scaling-factor) (2rem * $scaling-factor) (1.7rem * $scaling-factor)
 
   .navigation__item--user > a:hover
-    border-color: white
+    border-color: #fff
 
-  .header__search
-    color: white
-    @media (min-width: 67.5em)
-      height: (13rem * $scaling-factor)
-      font-size: 2rem
+
+
+
+
+  // ---------------------------------------------------------------------------
+  // mobile-navigation
+  // ---------------------------------------------------------------------------
+
+  .mobile-navigation
+    padding: (3rem * $scaling-factor)
+    width: (25rem * $scaling-factor)
+
+  // Pixel values for more precise measurements
+  .mobile-navigation__item
+    border-bottom-width: 1px
+    font-size: 18px
+
+    .icon
+      width: (1.3rem * $scaling-factor)
+      height: (1.3rem * $scaling-factor)
+      margin-top: (.6rem * $scaling-factor)
+
+  .mobile-navigation__link
+    padding: (1.6rem * $scaling-factor) 0 (1.1rem * $scaling-factor)
+
+  .mobile-navigation__item--active > .mobile-navigation__link
+    color: #333
+
+
+
+
+
+  // ---------------------------------------------------------------------------
+  // sub-navigation
+  // ---------------------------------------------------------------------------
 
   .sub-navigation
-    width: 23rem
-    margin-left: -11.5rem
+    border-radius: (.2rem * $scaling-factor)
+    width: (29rem * $scaling-factor)
+    margin-left: (-29rem / 2 * $scaling-factor)
     top: (10rem * $scaling-factor)
+    font-size: (1.8rem * $scaling-factor)
 
-    .sub-navigation__link
-      text-decoration: none
-      padding-top: .6rem
-      padding-bottom: .6rem
+    &:before
+      border: (.8rem * $scaling-factor) solid transparent
+      border-bottom-color: #fff
+      margin-left: (-.8rem * $scaling-factor)
+      top: (-1.6rem * $scaling-factor)
 
-  .sub-navigation-feature + .sub-navigation__list
-    padding-top: .5rem
-    padding-bottom: 1.5rem
+  .sub-navigation--visible
+    box-shadow: 0 $lp-gutter (9rem * $scaling-factor) rgba(0, 0, 0, .4)
+
+  .sub-navigation-feature
+    padding: $lp-gutter $lp-gutter (2rem * $scaling-factor)
+
+  .mobile-sub-navigation .sub-navigation-feature
+    padding: 0 0 (2rem * $scaling-factor)
 
   .sub-navigation-feature__image
     margin-right: (2.6rem * $scaling-factor)
     width: (8rem * $scaling-factor)
 
+  // Pixel width because rem calculation is 1 px off
+  .mobile-sub-navigation .sub-navigation-feature__image
+    margin-right: (1.4rem * $scaling-factor)
+    width: 60px
+
   .sub-navigation-feature__text
-    padding-top: 1.5rem
+    padding-top: ($lp-gutter / 2)
+
+  .mobile-sub-navigation .sub-navigation-feature__text
+    padding-top: (.8rem * $scaling-factor)
 
   .sub-navigation-feature__title
-    font-size: 1.4rem
+    font-size: (1.6rem * $scaling-factor)
 
   .sub-navigation-feature__subtitle
-    font-size: .9rem
-
-  .sub-navigation__item
-    font-size: 1.3rem
-
-  .header__search [class*="icon-"]
-    font-size: (2rem * $scaling-factor)
-
-  .avatar
-    height: 3rem
-    max-width: 3rem
-    width: 3rem
-
-  .header__mobile-search:before
-    font-size: (2.3rem * $scaling-factor)
-    line-height: 5rem
-
-  .header--narrow .header__mobile-search
-    color: white
-
-  .header--narrow .header__mobile-menu .menu-icon
-    color: white
-    background-color: white
-    &:before, &:after
-      color: white
-      background-color: white
-
-  .notification-badge--user
-    right: (-.2rem * $scaling-factor)
-    width: (1.5rem * $scaling-factor)
-    height: (1.5rem * $scaling-factor)
-    left: 2rem
-
-  .notification-badge--user-inline
-    left: 4.5rem
-    width: (1.0rem * $scaling-factor)
-    height: (1.0rem * $scaling-factor)
-    border: none
-
-  .notification-badge--shop
-    top: 3rem
-    left: 1.8rem
-
-  .notification-badge
-    width: 1.4rem
-    height: 1.4rem
-    font-size: 1rem
-    line-height: 1.5rem
-
-.mobile-navigation.mobile-navigation--visible
-  width: (25rem * $scaling-factor)
-  max-width: 50vw
-
-  .mobile-navigation__item
-    font-size: 1.5rem
-    & a
-      padding: (1.5rem * $scaling-factor) 0
-
-  .mobile-navigation__item--active a
-    color: black
-    
-  .mobile-navigation__link,
-  .sub-navigation__link
-    text-decoration: none
-    outline: 0
-
-  .sub-navigation__item
-    font-size: 1.3rem
-    margin-left: (3.0rem * $scaling-factor)
-
-  .sub-navigation-feature__subtitle
-    font-size: .9rem
+    font-size: (1.1rem * $scaling-factor)
     margin-top: (.4rem * $scaling-factor)
 
-  .sub-navigation-feature__title
-    font-size: 1.4rem
+  .sub-navigation__list
+    padding-bottom: (2.8rem * $scaling-factor)
+    padding-top: (2.8rem * $scaling-factor)
 
-  .mobile-navigation__item .icon
-    margin-top: .1rem
-
-  .mobile-sub-navigation .sub-navigation-feature__image
-    margin-right: (0.7rem * $scaling-factor)
-    width: 7rem
-
-  .mobile-sub-navigation .sub-navigation-feature
+  .sub-navigation-feature + .sub-navigation__list
     padding-top: 0
 
-.search.search--visible
+  .mobile-sub-navigation .sub-navigation__list
+    padding: 0
 
-  .search__container
-    max-width: 129rem
+  .sub-navigation__item
+    font-size: (1.6rem * $scaling-factor)
+    margin-left: $lp-gutter
+    margin-right: $lp-gutter
 
-    @media (max-width: 29.9375em)
-      padding-left: 1.5rem
-      padding-right: 1.5rem
+  .mobile-sub-navigation .sub-navigation__item
+    margin-left: 0
+    margin-right: 0
 
-    @media (min-width: 30em)
-      margin-left: 3rem
-      margin-right: 3rem
+  .sub-navigation__link
+    padding-top: (1rem * $scaling-factor)
+    padding-bottom: (.8rem * $scaling-factor)
 
-    @media (min-width: 67.5em)
-      margin-left: 6rem
-      margin-right: 6rem
+    &:after
+      height: calc(100% + .2rem)
+      left: -$lp-gutter
+      right: -$lp-gutter
+      top: (-.1rem * $scaling-factor)
+      width: calc(100% + #{$lp-gutter} + #{$lp-gutter})
 
-  .search__inner
-    @media (min-width: 45em)
+  .mobile-sub-navigation .sub-navigation__link
+    padding-left: ($lp-gutter / 2)
+    padding-right: ($lp-gutter / 2)
+
+  .sub-navigation__button
+    font-size: (1.2rem * $scaling-factor)
+    padding: (1.8rem * $scaling-factor) (3rem * $scaling-factor) (1.4rem * $scaling-factor)
+    border-radius: 0 0 (.2rem * $scaling-factor) (.2rem * $scaling-factor)
+    padding-top: (2.3rem * $scaling-factor)
+    padding-bottom: (1.9rem * $scaling-factor)
+
+
+
+
+
+  // ---------------------------------------------------------------------------
+  // search
+  // ---------------------------------------------------------------------------
+
+  .lp-search
+    @media (min-width: $lp-min-720)
+      box-shadow: (-5rem * $scaling-factor) 0 (15rem * $scaling-factor) rgba(0, 0, 0, .5)
+
+  .lp-search--visible
+    @media (min-width: $lp-min-720)
+      box-shadow: (.5rem * $scaling-factor) 0 (23rem * $scaling-factor) rgba(0, 0, 0, .5)
+
+  .lp-search__container
+    max-width: (129rem * $scaling-factor)
+    margin-left: auto
+    margin-right: auto
+
+    @media (max-width: $lp-max-480)
+      padding-left: ($lp-gutter / 2)
+      padding-right: ($lp-gutter / 2)
+
+    @media (min-width: $lp-min-480)
+      margin-left: $lp-gutter
+      margin-right: $lp-gutter
+
+    @media (min-width: $lp-min-1080)
+      margin-left: ($lp-gutter * 2)
+      margin-right: ($lp-gutter * 2)
+
+    @media (min-width: $lp-min-1410)
+      margin-left: auto
+      margin-right: auto
+
+  .lp-search__inner
+    height: (5rem * $scaling-factor)
+    line-height: (3.8rem * $scaling-factor)
+
+    @media (min-width: $lp-min-720)
       height: (13rem * $scaling-factor)
 
-  .search-item
-    margin-bottom: (1rem * $scaling-factor)
-    line-height: (6rem * $scaling-factor)
+    &:after
+      @media (max-width: $lp-max-720)
+        +lp-fade-edge("right", 29px)
 
-  .search-item__link
-    padding-left: (11rem * $scaling-factor)
-    &:hover
-      text-decoration: none
+  .lp-search__label
+    width: (2rem * $scaling-factor)
+    height: (2rem * $scaling-factor)
 
-  .search-item__name
-    font-size: (1.8rem * $scaling-factor)
-    @media (min-width: 45em)
-      font-size: (2.2rem * $scaling-factor)
+    @media (min-width: $lp-min-720)
+      top: (-.4rem * $scaling-factor)
 
-  .search__input
-    font-size: 1.6rem
-    @media (min-width: 45em)
-      font-size: 2rem
+    &:before
+      font-size: (2rem * $scaling-factor)
+
+  .lp-search__input
+    left: (2.5rem * $scaling-factor)
+    right: (5.9rem * $scaling-factor)
+    width: calc(100% - #{(5rem * $scaling-factor)} - #{(.9rem * $scaling-factor)})
+    height: (3.8rem * $scaling-factor)
+    font-size: (1.6rem * $scaling-factor)
+
+    @media (max-width: $lp-max-720)
+      padding-top: (.3rem * $scaling-factor)
+
+    @media (min-width: $lp-min-720)
       left: (4rem * $scaling-factor)
       right: (4rem * $scaling-factor)
+      font-size: (2.4rem * $scaling-factor)
+      padding-top: 1px
+      width: calc(100% - #{(8rem * $scaling-factor)})
 
-  .search__label
-    top: 0.5rem
+  .lp-search__close
+    width: (3.8rem * $scaling-factor)
+    height: (3.8rem * $scaling-factor)
+    right: (-.9rem * $scaling-factor)
+
+    @media (min-width: $lp-min-720)
+      right: 0
+
     &:before
-      font-size: (2rem * $scaling-factor)
+      font-size: (1.8rem * $scaling-factor)
 
-  .search__close:before
-    content: "\e605"
-    font-family: "dest-next-icons"
+      @media (min-width: $lp-min-720)
+        font-size: (2rem * $scaling-factor)
+
+  .lp-search-results
+    transform: translateY((-2rem * $scaling-factor))
+
+  .lp-search-results--visible
+    transform: translateY(0)
+
+  .lp-search-results__list
+    margin-bottom: ((4.5rem - .8rem) * $scaling-factor)
+    padding-top: (1rem * $scaling-factor)
+    border-top-width: 1px
+
+  // Pixel value for line-height so that it's more precise
+  .lp-search-item
+    margin-bottom: (1rem * $scaling-factor)
+    line-height: 60px
+
+  .lp-search-item__link
+    padding-left: (11rem * $scaling-factor)
+
+  .lp-search-item__name
     font-size: (1.8rem * $scaling-factor)
-    @media (min-width: 45em)
-    .search__close:before
-      font-size: (2rem * $scaling-factor)
+    border-bottom-width: 1px
+
+    @media (min-width: $lp-min-720)
+      font-size: (2.2rem * $scaling-factor)
+      transform: translateX(0)
+
+  .lp-search-item:hover,
+  .lp-search-item:active,
+  .lp-search-item:focus,
+  .lp-search-item--selected
+    .lp-search-item__name
+      @media (min-width: $lp-min-720)
+        transform: translateX(7px)
+
+  .lp-search-results__more
+    margin-bottom: (4.5rem * $scaling-factor)
+    font-size: (1.2rem * $scaling-factor)
+
+  .lp-search-results__more
+    [class*="icon-"]
+      transform: translateX(6px)
+
+    &:hover [class*="icon-"],
+    &:active [class*="icon-"],
+    &:focus [class*="icon-"]
+      transform: translateX(2px)
+
+
+
+
+
+  // ---------------------------------------------------------------------------
+  // avatar
+  // ---------------------------------------------------------------------------
+
+  // pixel values for exact sizing
+  .avatar
+    height: 40px
+    max-width: 40px
+    width: 40px
+
+  // adjusting position
+  .navigation__item--user .avatar
+    right: -1px
+
+  .navigation__item--user > a.avatar
+    padding: 0
+
+  .avatar--navigation
+    top: (-.4rem * $scaling-factor)
+
+
+
+
+
+  // ---------------------------------------------------------------------------
+  // notification-badge
+  // ---------------------------------------------------------------------------
+
+  // pixel values for finer control and exact positioning, sizing
+  .notification-badge
+    width: 17px
+    height: 17px
+    font-size: 10px
+    line-height: 18px
+
+  // pixel values for finer control and exact positioning, sizing
+  .notification-badge--user
+    right: -2px
+    width: 15px
+    height: 15px
+
+  // rem too small to work for dimensions
+  .notification-badge--user-inline
+    top: (-.5rem * $scaling-factor)
+    right: (-1.1rem * $scaling-factor)
+    width: 12px
+    height: 12px
+
+  // pixel values for finer control and exact positioning, sizing
+  .notification-badge--shop
+    top: 46.5px
+    right: -6px
+
+  // pixel values for finer control and exact positioning, sizing
+  .notification-badge--shop-inline
+    left: 46px
+    top: 18px
+    width: 6px
+    height: 6px
+
+  // pixel values for finer control and exact positioning, sizing
+  .notification-badge--mobile-menu
+    top: 16px
+    right: 12px
+    width: 6px
+    height: 6px
+
+
+
+
+
+  // ---------------------------------------------------------------------------
+  // topic
+  // ---------------------------------------------------------------------------
+
+  .topic
+    position: relative
 
   .topic__image
-    width: (8rem * $scaling-factor)
+    background-color: #ccc
+    background-repeat: no-repeat
+    background-size: cover
     height: (6rem * $scaling-factor)
+    width: (8rem * $scaling-factor)
+    left: 0
+    position: absolute
+    top: 0
 
-    // workaround for no-freight
-    &:before
-      top: 50%
-      left: 50%
-      margin-right: -50%
-      transform: translate(-50%, -50%)
+  .topic__image--activity
+    +lp-icon-before("https://assets.staticlp.com/destinations-next/icons/activity--line.svg")
+    background-image: url("https://assets.staticlp.com/destinations-next/images/search-category-image-activities.jpg")
+
+  .topic__image--article
+    +lp-icon-before("https://assets.staticlp.com/destinations-next/icons/article--line.svg")
+    background-image: url("https://assets.staticlp.com/destinations-next/images/search-category-image-articles.jpg")
+
+  .topic__image--collection
+    +lp-icon-before("https://assets.staticlp.com/destinations-next/icons/image--line.svg")
+    background-image: url("https://assets.staticlp.com/destinations-next/images/search-category-image-collection.jpg")
+
+  .topic__image--guide
+    +lp-icon-before("https://assets.staticlp.com/destinations-next/icons/book.svg")
+    background-image: url("https://assets.staticlp.com/destinations-next/images/search-category-image-guides.jpg")
+
+  .topic__image--hotel
+    +lp-icon-before("https://assets.staticlp.com/destinations-next/icons/hotel--line.svg")
+    background-image: url("https://assets.staticlp.com/destinations-next/images/search-category-image-hotels.jpg")
+
+  .topic__image--place
+    +lp-icon-before("https://assets.staticlp.com/destinations-next/icons/place.svg")
+    background-image: url("https://assets.staticlp.com/destinations-next/images/search-category-image-place.jpg")
+
+  .topic__image--sight
+    +lp-icon-before("https://assets.staticlp.com/destinations-next/icons/sight--line.svg")
+    background-image: url("https://assets.staticlp.com/destinations-next/images/search-category-image-sights.jpg")
+
+  .topic__image--tour
+    +lp-icon-before("https://assets.staticlp.com/destinations-next/icons/tour--line.svg")
+    background-image: url("https://assets.staticlp.com/destinations-next/images/search-category-image-tours.jpg")

--- a/app/assets/stylesheets/core/layouts/modern/_primary_nav_new.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_primary_nav_new.sass
@@ -163,7 +163,7 @@ $lp-blue: #287bbb
       line-height: 100%
 
     [class*="icon-"]
-      margin-right: (1.5rem * $scaling-factor)
+      margin-right: (1.2rem * $scaling-factor)
       font-size: (2rem * $scaling-factor)
 
     &:hover,
@@ -250,10 +250,10 @@ $lp-blue: #287bbb
     &:not(:last-child)
       margin-right: (4rem * $scaling-factor)
 
-  .navigation__item--user > a
+  .navigation__item--user > .navigation__link
     border-width: 1px
-    border-radius: (2.2rem * $scaling-factor)
-    padding: (1.7rem * $scaling-factor) (2rem * $scaling-factor)
+    border-radius: (1.7rem * $scaling-factor)
+    padding: (1.7rem * $scaling-factor) (2rem * $scaling-factor) (1.5rem * $scaling-factor)
 
   .navigation__link
     font-size: (1.4rem * $scaling-factor)

--- a/app/assets/stylesheets/core/layouts/modern/_primary_nav_new.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_primary_nav_new.sass
@@ -76,6 +76,12 @@ $lp-blue: #287bbb
 $lp-color-red: #dc221a
 $lp-notification-badge-size: 17px
 
+@mixin lp-font-size($sizeValue, $baseValue: 10)
+  $value: strip-unit($sizeValue)
+  font-size: #{$value * $baseValue + px}
+  @if unit($sizeValue) == "rem"
+    font-size: ($sizeValue * $scaling-factor)
+
 %lp-icon-font
   font-family: "dest-next-icons"
   -moz-osx-font-smoothing: grayscale
@@ -138,14 +144,14 @@ $lp-notification-badge-size: 17px
     color: #fff
 
     @media (min-width: $lp-min-1080)
+      +lp-font-size(2.4rem)
       height: 100%
-      font-size: (2.4rem * $scaling-factor)
       margin-top: (-6.5rem * $scaling-factor)
       line-height: 100%
 
     [class*="icon-"]
+      +lp-font-size(2rem)
       margin-right: (1.2rem * $scaling-factor)
-      font-size: (2rem * $scaling-factor)
 
     &:hover,
     &:active,
@@ -161,15 +167,13 @@ $lp-notification-badge-size: 17px
     left: ($lp-gutter / -2)
 
   .header__mobile-search
-    width: (5rem * $scaling-factor)
-    height: (5rem * $scaling-factor)
+    +size((5rem * $scaling-factor))
 
     &:before
       margin-left: (.4rem * $scaling-factor)
 
   .header__mobile-menu
-    height: (5rem * $scaling-factor)
-    width: (5rem * $scaling-factor)
+    +size((5rem * $scaling-factor))
 
   // Pixel value for line-height to be more precise
   .header__mobile-search,
@@ -178,7 +182,7 @@ $lp-notification-badge-size: 17px
     line-height: 50px
 
     &:before
-      font-size: (2.3rem * $scaling-factor)
+      +lp-font-size(2.3rem)
 
   .header--narrow .header__mobile-search,
   .header--narrow .header__mobile-menu,
@@ -199,9 +203,8 @@ $lp-notification-badge-size: 17px
   .header__mobile-menu .menu-icon,
   .header__mobile-menu .menu-icon:before,
   .header__mobile-menu .menu-icon:after
-    height: (.2rem * $scaling-factor)
+    +size((2rem * $scaling-factor), (.2rem * $scaling-factor))
     background-color: #fff
-    width: (2rem * $scaling-factor)
 
   .header--narrow .header__mobile-menu .menu-icon,
   .header--narrow .header__mobile-menu .menu-icon:before,
@@ -232,7 +235,7 @@ $lp-notification-badge-size: 17px
       margin-right: (1.7rem * $scaling-factor)
 
   .navigation__link
-    font-size: (1.4rem * $scaling-factor)
+    +lp-font-size(1.4rem)
     text-decoration: none
     transition: color 400ms
 
@@ -274,13 +277,13 @@ $lp-notification-badge-size: 17px
   // ---------------------------------------------------------------------------
 
   .sub-navigation
+    +lp-font-size(1.8rem)
     font-family: inherit
     box-sizing: inherit
     border-radius: (.2rem * $scaling-factor)
     width: (29rem * $scaling-factor)
     margin-left: ((-29rem / 2 + .1) * $scaling-factor)
     top: (10rem * $scaling-factor)
-    font-size: (1.8rem * $scaling-factor)
 
     @media (max-width: $lp-max-1530)
       right: 0
@@ -308,10 +311,10 @@ $lp-notification-badge-size: 17px
     padding-top: ($lp-gutter / 2)
 
   .sub-navigation-feature__title
-    font-size: (1.6rem * $scaling-factor)
+    +lp-font-size(1.6rem)
 
   .sub-navigation-feature__subtitle
-    font-size: (1.1rem * $scaling-factor)
+    +lp-font-size(1.1rem)
     margin-top: (.4rem * $scaling-factor)
 
   .sub-navigation__list
@@ -322,7 +325,7 @@ $lp-notification-badge-size: 17px
     padding-top: 0
 
   .sub-navigation__item
-    font-size: (1.6rem * $scaling-factor)
+    +lp-font-size(1.6rem)
     margin-left: $lp-gutter
     margin-right: $lp-gutter
 
@@ -332,14 +335,13 @@ $lp-notification-badge-size: 17px
     text-decoration: none
 
     &:after
-      height: calc(100% + .2rem)
+      +size(calc(100% + #{$lp-gutter} + #{$lp-gutter}), calc(100% + .2rem))
       left: -$lp-gutter
       right: -$lp-gutter
       top: (-.1rem * $scaling-factor)
-      width: calc(100% + #{$lp-gutter} + #{$lp-gutter})
 
   .sub-navigation__button
-    font-size: (1.2rem * $scaling-factor)
+    +lp-font-size(1.2rem)
     padding: (1.8rem * $scaling-factor) (3rem * $scaling-factor) (1.4rem * $scaling-factor)
     border-radius: 0 0 (.2rem * $scaling-factor) (.2rem * $scaling-factor)
     padding-top: (2.3rem * $scaling-factor)
@@ -355,9 +357,8 @@ $lp-notification-badge-size: 17px
 
   // pixel values for exact sizing
   .avatar
-    height: 40px
+    +size(40px)
     max-width: 40px
-    width: 40px
 
   // adjusting position
   .navigation__item--user .avatar
@@ -383,8 +384,7 @@ $lp-notification-badge-size: 17px
   // ---------------------------------------------------------------------------
 
   .notification-badge
-    width: $lp-notification-badge-size
-    height: $lp-notification-badge-size
+    +size($lp-notification-badge-size)
     font-size: 10px
     font-weight: bold
     font-style: normal
@@ -408,11 +408,10 @@ $lp-notification-badge-size: 17px
     right: -6px
 
   .notification-badge--shop-inline
+    +size(6px)
     position: absolute
     left: 46px
     top: 18px
-    width: 6px
-    height: 6px
 
   .notification-badge--user,
   .notification-badge--user-inline
@@ -420,23 +419,20 @@ $lp-notification-badge-size: 17px
     border: 3px solid #fff
 
   .notification-badge--user
+    +size(15px)
     top: 0
     right: -2px
-    width: 15px
-    height: 15px
 
   .notification-badge--user-inline
+    +size(12px)
     top: -5px
     right: -11px
-    width: 12px
-    height: 12px
 
   .notification-badge--mobile-menu
+    +size(6px)
     position: absolute
     top: 16px
     right: 12px
-    width: 6px
-    height: 6px
     z-index: 2
 
 // ---------------------------------------------------------------------------
@@ -445,8 +441,7 @@ $lp-notification-badge-size: 17px
 
 // pixel values for finer control and exact positioning, sizing
 .lp-notification-badge
-  width: 17px
-  height: 17px
+  +size(17px)
   font-size: 10px
   line-height: 18px
 
@@ -457,30 +452,26 @@ $lp-notification-badge-size: 17px
 
 // pixel values for finer control and exact positioning, sizing
 .lp-notification-badge--shop-inline
+  +size(6px)
   left: 46px
   top: 18px
-  width: 6px
-  height: 6px
 
 // pixel values for finer control and exact positioning, sizing
 .lp-notification-badge--user
+  +size(15px)
   right: -2px
-  width: 15px
-  height: 15px
 
 // rem too small to work for dimensions
 .lp-notification-badge--user-inline
+  +size(12px)
   top: (-.5rem * $scaling-factor)
   right: (-1.1rem * $scaling-factor)
-  width: 12px
-  height: 12px
 
 // pixel values for finer control and exact positioning, sizing
 .lp-notification-badge--mobile-menu
+  +size(6px)
   top: 16px
   right: 12px
-  width: 6px
-  height: 6px
 
 
 
@@ -497,8 +488,7 @@ $lp-notification-badge-size: 17px
   width: (25rem * $scaling-factor)
 
   .notification-badge
-    width: $lp-notification-badge-size
-    height: $lp-notification-badge-size
+    +size($lp-notification-badge-size)
     font-size: 10px
     font-weight: bold
     font-style: normal
@@ -522,11 +512,10 @@ $lp-notification-badge-size: 17px
     right: -6px
 
   .notification-badge--shop-inline
+    +size(6px)
     position: absolute
     left: 46px
     top: 18px
-    width: 6px
-    height: 6px
 
   .notification-badge--user,
   .notification-badge--user-inline
@@ -534,23 +523,20 @@ $lp-notification-badge-size: 17px
     border: 3px solid #fff
 
   .notification-badge--user
+    +size(15px)
     top: 0
     right: -2px
-    width: 15px
-    height: 15px
 
   .notification-badge--user-inline
+    +size(12px)
     top: -5px
     right: -11px
-    width: 12px
-    height: 12px
 
   .notification-badge--mobile-menu
+    +size(6px)
     position: absolute
     top: 16px
     right: 12px
-    width: 6px
-    height: 6px
     z-index: 2
 
 // Pixel values for more precise measurements
@@ -559,8 +545,7 @@ $lp-notification-badge-size: 17px
   font-size: 18px
 
   .icon
-    width: (1.3rem * $scaling-factor)
-    height: (1.3rem * $scaling-factor)
+    +size((1.3rem * $scaling-factor))
     margin-top: (.6rem * $scaling-factor)
 
 .mobile-navigation__link
@@ -594,17 +579,17 @@ $lp-notification-badge-size: 17px
   padding-top: (.8rem * $scaling-factor)
 
 .mobile-sub-navigation .sub-navigation-feature__title
-  font-size: (1.6rem * $scaling-factor)
+  +lp-font-size(1.6rem)
 
 .mobile-sub-navigation .sub-navigation-feature__subtitle
-  font-size: (1.1rem * $scaling-factor)
+  +lp-font-size(1.1rem)
   margin-top: (.4rem * $scaling-factor)
 
 .mobile-sub-navigation .sub-navigation__list
   padding: 0
 
 .mobile-sub-navigation .sub-navigation__item
-  font-size: (1.6rem * $scaling-factor)
+  +lp-font-size(1.6rem)
   margin-left: 0
   margin-right: 0
 
@@ -613,14 +598,13 @@ $lp-notification-badge-size: 17px
   text-decoration: none
 
   &:after
-    height: calc(100% + .2rem)
+    +size(calc(100% + #{$lp-gutter} + #{$lp-gutter}), calc(100% + .2rem))
     left: -$lp-gutter
     right: -$lp-gutter
     top: (-.1rem * $scaling-factor)
-    width: calc(100% + #{$lp-gutter} + #{$lp-gutter})
 
 .mobile-sub-navigation .sub-navigation__button
-  font-size: (1.2rem * $scaling-factor)
+  +lp-font-size(1.2rem)
   padding: (1.8rem * $scaling-factor) (3rem * $scaling-factor) (1.4rem * $scaling-factor)
   border-radius: 0 0 (.2rem * $scaling-factor) (.2rem * $scaling-factor)
   padding-top: (2.3rem * $scaling-factor)
@@ -691,45 +675,42 @@ $lp-notification-badge-size: 17px
       width: 30px
 
 .lp-search__label
-  width: (2rem * $scaling-factor)
-  height: (2rem * $scaling-factor)
+  +size((2rem * $scaling-factor))
 
   @media (min-width: $lp-min-720)
     top: (-.4rem * $scaling-factor)
 
   &:before
-    font-size: (2rem * $scaling-factor)
+    +lp-font-size(2rem)
 
 .lp-search__input
+  +lp-font-size(1.6rem)
+  +size(calc(100% - #{(5rem * $scaling-factor)} - #{(.9rem * $scaling-factor)}), (3.8rem * $scaling-factor))
   left: (2.5rem * $scaling-factor)
   right: (5.9rem * $scaling-factor)
-  width: calc(100% - #{(5rem * $scaling-factor)} - #{(.9rem * $scaling-factor)})
-  height: (3.8rem * $scaling-factor)
-  font-size: (1.6rem * $scaling-factor)
 
   @media (max-width: $lp-max-720)
     padding-top: (.3rem * $scaling-factor)
 
   @media (min-width: $lp-min-720)
+    +lp-font-size(2.4rem)
     left: (3.4rem * $scaling-factor)
     right: (3.4rem * $scaling-factor)
-    font-size: (2.4rem * $scaling-factor)
     padding-top: 1px
     width: calc(100% - #{(8rem * $scaling-factor)})
 
 .lp-search__close
-  width: (3.8rem * $scaling-factor)
-  height: (3.8rem * $scaling-factor)
+  +size((3.8rem * $scaling-factor))
   right: (-.9rem * $scaling-factor)
 
   @media (min-width: $lp-min-720)
     right: 0
 
   &:before
-    font-size: (1.8rem * $scaling-factor)
+    +lp-font-size(1.8rem)
 
     @media (min-width: $lp-min-720)
-      font-size: (2rem * $scaling-factor)
+      +lp-font-size(2rem)
 
 .lp-search-results
   transform: translateY((-2rem * $scaling-factor))
@@ -752,11 +733,11 @@ $lp-notification-badge-size: 17px
   text-decoration: none
 
 .lp-search-item__name
-  font-size: (1.8rem * $scaling-factor)
+  +lp-font-size(1.8rem)
   border-bottom-width: 1px
 
   @media (min-width: $lp-min-720)
-    font-size: (2.2rem * $scaling-factor)
+    +lp-font-size(2.2rem)
     transform: translateX(0)
 
 .lp-search-item:hover,
@@ -768,8 +749,8 @@ $lp-notification-badge-size: 17px
       transform: translateX(7px)
 
 .lp-search-results__more
+  +lp-font-size(1.2rem)
   margin-bottom: (4.5rem * $scaling-factor)
-  font-size: (1.2rem * $scaling-factor)
 
 .lp-search-results__more
   color: $lp-blue
@@ -797,5 +778,4 @@ $lp-notification-badge-size: 17px
 // ---------------------------------------------------------------------------
 
 .topic__image
-  height: (6rem * $scaling-factor)
-  width: (8rem * $scaling-factor)
+  +size((8rem * $scaling-factor), (6rem * $scaling-factor))

--- a/app/assets/stylesheets/core/layouts/modern/_primary_nav_new.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_primary_nav_new.sass
@@ -383,13 +383,10 @@ $lp-notification-badge-size: 17px
     border-radius: 50%
     background-color: $lp-color-red
     user-select: none
-
-  // override Rizzo
-  .notification-badge
+    // override Rizzo
     box-sizing: border-box
     box-shadow: none
     left: auto
-
 
   .notification-badge__wrap
     position: relative
@@ -431,46 +428,48 @@ $lp-notification-badge-size: 17px
     height: 6px
     z-index: 2
 
-  // namespaced styles
+// ---------------------------------------------------------------------------
+// notification-badge (namespaced)
+// ---------------------------------------------------------------------------
 
-  // pixel values for finer control and exact positioning, sizing
-  .lp-notification-badge
-    width: 17px
-    height: 17px
-    font-size: 10px
-    line-height: 18px
+// pixel values for finer control and exact positioning, sizing
+.lp-notification-badge
+  width: 17px
+  height: 17px
+  font-size: 10px
+  line-height: 18px
 
-  // pixel values for finer control and exact positioning, sizing
-  .lp-notification-badge--shop
-    top: 46.5px
-    right: -6px
+// pixel values for finer control and exact positioning, sizing
+.lp-notification-badge--shop
+  top: 46.5px
+  right: -6px
 
-  // pixel values for finer control and exact positioning, sizing
-  .lp-notification-badge--shop-inline
-    left: 46px
-    top: 18px
-    width: 6px
-    height: 6px
+// pixel values for finer control and exact positioning, sizing
+.lp-notification-badge--shop-inline
+  left: 46px
+  top: 18px
+  width: 6px
+  height: 6px
 
-  // pixel values for finer control and exact positioning, sizing
-  .lp-notification-badge--user
-    right: -2px
-    width: 15px
-    height: 15px
+// pixel values for finer control and exact positioning, sizing
+.lp-notification-badge--user
+  right: -2px
+  width: 15px
+  height: 15px
 
-  // rem too small to work for dimensions
-  .lp-notification-badge--user-inline
-    top: (-.5rem * $scaling-factor)
-    right: (-1.1rem * $scaling-factor)
-    width: 12px
-    height: 12px
+// rem too small to work for dimensions
+.lp-notification-badge--user-inline
+  top: (-.5rem * $scaling-factor)
+  right: (-1.1rem * $scaling-factor)
+  width: 12px
+  height: 12px
 
-  // pixel values for finer control and exact positioning, sizing
-  .lp-notification-badge--mobile-menu
-    top: 16px
-    right: 12px
-    width: 6px
-    height: 6px
+// pixel values for finer control and exact positioning, sizing
+.lp-notification-badge--mobile-menu
+  top: 16px
+  right: 12px
+  width: 6px
+  height: 6px
 
 
 
@@ -486,6 +485,63 @@ $lp-notification-badge-size: 17px
   padding: (3rem * $scaling-factor)
   width: (25rem * $scaling-factor)
 
+  .notification-badge
+    width: $lp-notification-badge-size
+    height: $lp-notification-badge-size
+    font-size: 10px
+    font-weight: bold
+    font-style: normal
+    line-height: ($lp-notification-badge-size + 1)
+    text-align: center
+    color: #fff
+    border-radius: 50%
+    background-color: $lp-color-red
+    user-select: none
+    // override Rizzo
+    box-sizing: border-box
+    box-shadow: none
+    left: auto
+
+  .notification-badge__wrap
+    position: relative
+
+  .notification-badge--shop
+    position: absolute
+    top: 46.5px
+    right: -6px
+
+  .notification-badge--shop-inline
+    position: absolute
+    left: 46px
+    top: 18px
+    width: 6px
+    height: 6px
+
+  .notification-badge--user,
+  .notification-badge--user-inline
+    position: absolute
+    border: 3px solid #fff
+
+  .notification-badge--user
+    top: 0
+    right: -2px
+    width: 15px
+    height: 15px
+
+  .notification-badge--user-inline
+    top: -5px
+    right: -11px
+    width: 12px
+    height: 12px
+
+  .notification-badge--mobile-menu
+    position: absolute
+    top: 16px
+    right: 12px
+    width: 6px
+    height: 6px
+    z-index: 2
+
 // Pixel values for more precise measurements
 .mobile-navigation__item
   border-bottom-width: 1px
@@ -499,7 +555,7 @@ $lp-notification-badge-size: 17px
 .mobile-navigation__link
   line-height: 1.5
   padding: (1.6rem * $scaling-factor) 0 (1.1rem * $scaling-factor)
-  text-decoration: none
+  text-decoration: none !important
 
 .mobile-navigation__item--active > .mobile-navigation__link
   color: #333

--- a/app/assets/stylesheets/core/layouts/modern/_primary_nav_new.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_primary_nav_new.sass
@@ -1,4 +1,48 @@
 // -----------------------------------------------------------------------------
+// Fonts
+// -----------------------------------------------------------------------------
+
+@font-face
+  font-family: "Benton Sans"
+  src: url("https://assets.staticlp.com/javascripts/2c8c3478-e1ba-4af3-bfd0-9fea259fc17f-2.eot")
+  src: url("https://assets.staticlp.com/javascripts/2c8c3478-e1ba-4af3-bfd0-9fea259fc17f-2.eot?") format("embedded-opentype"), url("https://assets.staticlp.com/javascripts/2c8c3478-e1ba-4af3-bfd0-9fea259fc17f-3.woff") format("woff"), url("https://assets.staticlp.com/javascripts/2c8c3478-e1ba-4af3-bfd0-9fea259fc17f-1.ttf") format("truetype")
+  font-style: normal
+  font-stretch: normal
+  font-weight: 300
+
+@font-face
+  font-family: "Benton Sans"
+  src: url("https://assets.staticlp.com/javascripts/19319132-31a6-45e2-85a5-6dacae897490-2.eot")
+  src: url("https://assets.staticlp.com/javascripts/19319132-31a6-45e2-85a5-6dacae897490-2.eot?") format("embedded-opentype"), url("https://assets.staticlp.com/javascripts/19319132-31a6-45e2-85a5-6dacae897490-3.woff") format("woff"), url("https://assets.staticlp.com/javascripts/19319132-31a6-45e2-85a5-6dacae897490-1.ttf") format("truetype")
+  font-style: normal
+  font-stretch: normal
+  font-weight: 500
+
+@font-face
+  font-family: "Benton Sans"
+  src: url("https://assets.staticlp.com/javascripts/743d3d3a-da58-48d2-a5c3-bd7994650e23-2.eot")
+  src: url("https://assets.staticlp.com/javascripts/743d3d3a-da58-48d2-a5c3-bd7994650e23-2.eot?") format("embedded-opentype"), url("https://assets.staticlp.com/javascripts/743d3d3a-da58-48d2-a5c3-bd7994650e23-3.woff") format("woff"), url("https://assets.staticlp.com/javascripts/743d3d3a-da58-48d2-a5c3-bd7994650e23-1.ttf") format("truetype")
+  font-style: normal
+  font-stretch: normal
+  font-weight: 600
+
+@font-face
+  font-family: "Miller Daily"
+  src: url("https://assets.staticlp.com/javascripts/2d4b6287-e087-4bce-89af-61a0cd634f27-2.eot")
+  src: url("https://assets.staticlp.com/javascripts/2d4b6287-e087-4bce-89af-61a0cd634f27-2.eot?") format("embedded-opentype"), url("https://assets.staticlp.com/javascripts/2d4b6287-e087-4bce-89af-61a0cd634f27-3.woff") format("woff"), url("https://assets.staticlp.com/javascripts/2d4b6287-e087-4bce-89af-61a0cd634f27-1.ttf") format("truetype")
+  font-style: italic
+  font-weight: normal
+  font-stretch: normal
+
+@font-face
+  font-family: "Miller Daily"
+  src: url("https://assets.staticlp.com/javascripts/6e603ae4-800b-4625-9fa8-1819315263a6-2.eot")
+  src: url("https://assets.staticlp.com/javascripts/6e603ae4-800b-4625-9fa8-1819315263a6-2.eot?") format("embedded-opentype"), url("https://assets.staticlp.com/javascripts/6e603ae4-800b-4625-9fa8-1819315263a6-3.woff") format("woff"), url("https://assets.staticlp.com/javascripts/6e603ae4-800b-4625-9fa8-1819315263a6-1.ttf") format("truetype")
+  font-style: normal
+  font-weight: normal
+  font-stretch: normal
+
+// -----------------------------------------------------------------------------
 // Variables
 // -----------------------------------------------------------------------------
 
@@ -27,6 +71,8 @@ $lp-min-320: #{(320 * .0625)}em   // 20em
 $lp-max-720: #{(719 * .0625)}em // 44.9375em
 $lp-max-480: #{(479 * .0625)}em // 29.9375em
 
+$lp-blue: #287bbb
+
 @mixin lp-fade-edge($side: "right", $offset: 0, $width: 30px, $color: #fff)
   background-image: linear-gradient(to left, $color 0%, rgba($color, 0) 100%)
   bottom: 0
@@ -49,7 +95,19 @@ $lp-max-480: #{(479 * .0625)}em // 29.9375em
     position: relative
     width: 82px
 
+%lp-icon-font
+  font-family: "dest-next-icons"
+  -moz-osx-font-smoothing: grayscale
+  -webkit-font-smoothing: antialiased
+  font-style: normal
+  font-variant: normal
+  font-weight: normal
+  line-height: 1
+  speak: none
+  text-transform: none
+
 .content-wrapper.navigation-wrapper.rizzo-navigation.rizzo-next
+  box-sizing: border-box
 
   // ---------------------------------------------------------------------------
   // header
@@ -57,6 +115,8 @@ $lp-max-480: #{(479 * .0625)}em // 29.9375em
 
   .header
     background-color: $navblue
+    box-sizing: inherit
+    font-family: "Benton Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif
 
   .header__container
     max-width: (129rem * $scaling-factor)
@@ -102,9 +162,15 @@ $lp-max-480: #{(479 * .0625)}em // 29.9375em
       margin-top: (-6.5rem * $scaling-factor)
       line-height: 100%
 
-  .header__search [class*="icon-"]
-    margin-right: (1.5rem * $scaling-factor)
-    font-size: (2rem * $scaling-factor)
+    [class*="icon-"]
+      margin-right: (1.5rem * $scaling-factor)
+      font-size: (2rem * $scaling-factor)
+
+    &:hover,
+    &:active,
+    &:focus
+      [class*="icon-"]
+        margin-right: (($lp-gutter / 2) / 4) * 3
 
   .header__mobile
     right: ($lp-gutter / -2)
@@ -171,6 +237,7 @@ $lp-max-480: #{(479 * .0625)}em // 29.9375em
 
   // pixel value here because rem calculation is 1 px off
   .navigation
+    box-sizing: inherit
     line-height: 130px
 
   .navigation__item--active
@@ -218,38 +285,12 @@ $lp-max-480: #{(479 * .0625)}em // 29.9375em
 
 
   // ---------------------------------------------------------------------------
-  // mobile-navigation
-  // ---------------------------------------------------------------------------
-
-  .mobile-navigation
-    padding: (3rem * $scaling-factor)
-    width: (25rem * $scaling-factor)
-
-  // Pixel values for more precise measurements
-  .mobile-navigation__item
-    border-bottom-width: 1px
-    font-size: 18px
-
-    .icon
-      width: (1.3rem * $scaling-factor)
-      height: (1.3rem * $scaling-factor)
-      margin-top: (.6rem * $scaling-factor)
-
-  .mobile-navigation__link
-    padding: (1.6rem * $scaling-factor) 0 (1.1rem * $scaling-factor)
-
-  .mobile-navigation__item--active > .mobile-navigation__link
-    color: #333
-
-
-
-
-
-  // ---------------------------------------------------------------------------
   // sub-navigation
   // ---------------------------------------------------------------------------
 
   .sub-navigation
+    font-family: inherit
+    box-sizing: inherit
     border-radius: (.2rem * $scaling-factor)
     width: (29rem * $scaling-factor)
     margin-left: (-29rem / 2 * $scaling-factor)
@@ -268,23 +309,12 @@ $lp-max-480: #{(479 * .0625)}em // 29.9375em
   .sub-navigation-feature
     padding: $lp-gutter $lp-gutter (2rem * $scaling-factor)
 
-  .mobile-sub-navigation .sub-navigation-feature
-    padding: 0 0 (2rem * $scaling-factor)
-
   .sub-navigation-feature__image
     margin-right: (2.6rem * $scaling-factor)
     width: (8rem * $scaling-factor)
 
-  // Pixel width because rem calculation is 1 px off
-  .mobile-sub-navigation .sub-navigation-feature__image
-    margin-right: (1.4rem * $scaling-factor)
-    width: 60px
-
   .sub-navigation-feature__text
     padding-top: ($lp-gutter / 2)
-
-  .mobile-sub-navigation .sub-navigation-feature__text
-    padding-top: (.8rem * $scaling-factor)
 
   .sub-navigation-feature__title
     font-size: (1.6rem * $scaling-factor)
@@ -300,21 +330,15 @@ $lp-max-480: #{(479 * .0625)}em // 29.9375em
   .sub-navigation-feature + .sub-navigation__list
     padding-top: 0
 
-  .mobile-sub-navigation .sub-navigation__list
-    padding: 0
-
   .sub-navigation__item
     font-size: (1.6rem * $scaling-factor)
     margin-left: $lp-gutter
     margin-right: $lp-gutter
 
-  .mobile-sub-navigation .sub-navigation__item
-    margin-left: 0
-    margin-right: 0
-
   .sub-navigation__link
     padding-top: (1rem * $scaling-factor)
     padding-bottom: (.8rem * $scaling-factor)
+    text-decoration: none
 
     &:after
       height: calc(100% + .2rem)
@@ -323,153 +347,12 @@ $lp-max-480: #{(479 * .0625)}em // 29.9375em
       top: (-.1rem * $scaling-factor)
       width: calc(100% + #{$lp-gutter} + #{$lp-gutter})
 
-  .mobile-sub-navigation .sub-navigation__link
-    padding-left: ($lp-gutter / 2)
-    padding-right: ($lp-gutter / 2)
-
   .sub-navigation__button
     font-size: (1.2rem * $scaling-factor)
     padding: (1.8rem * $scaling-factor) (3rem * $scaling-factor) (1.4rem * $scaling-factor)
     border-radius: 0 0 (.2rem * $scaling-factor) (.2rem * $scaling-factor)
     padding-top: (2.3rem * $scaling-factor)
     padding-bottom: (1.9rem * $scaling-factor)
-
-
-
-
-
-  // ---------------------------------------------------------------------------
-  // search
-  // ---------------------------------------------------------------------------
-
-  .lp-search
-    @media (min-width: $lp-min-720)
-      box-shadow: (-5rem * $scaling-factor) 0 (15rem * $scaling-factor) rgba(0, 0, 0, .5)
-
-  .lp-search--visible
-    @media (min-width: $lp-min-720)
-      box-shadow: (.5rem * $scaling-factor) 0 (23rem * $scaling-factor) rgba(0, 0, 0, .5)
-
-  .lp-search__container
-    max-width: (129rem * $scaling-factor)
-    margin-left: auto
-    margin-right: auto
-
-    @media (max-width: $lp-max-480)
-      padding-left: ($lp-gutter / 2)
-      padding-right: ($lp-gutter / 2)
-
-    @media (min-width: $lp-min-480)
-      margin-left: $lp-gutter
-      margin-right: $lp-gutter
-
-    @media (min-width: $lp-min-1080)
-      margin-left: ($lp-gutter * 2)
-      margin-right: ($lp-gutter * 2)
-
-    @media (min-width: $lp-min-1410)
-      margin-left: auto
-      margin-right: auto
-
-  .lp-search__inner
-    height: (5rem * $scaling-factor)
-    line-height: (3.8rem * $scaling-factor)
-
-    @media (min-width: $lp-min-720)
-      height: (13rem * $scaling-factor)
-
-    &:after
-      @media (max-width: $lp-max-720)
-        +lp-fade-edge("right", 29px)
-
-  .lp-search__label
-    width: (2rem * $scaling-factor)
-    height: (2rem * $scaling-factor)
-
-    @media (min-width: $lp-min-720)
-      top: (-.4rem * $scaling-factor)
-
-    &:before
-      font-size: (2rem * $scaling-factor)
-
-  .lp-search__input
-    left: (2.5rem * $scaling-factor)
-    right: (5.9rem * $scaling-factor)
-    width: calc(100% - #{(5rem * $scaling-factor)} - #{(.9rem * $scaling-factor)})
-    height: (3.8rem * $scaling-factor)
-    font-size: (1.6rem * $scaling-factor)
-
-    @media (max-width: $lp-max-720)
-      padding-top: (.3rem * $scaling-factor)
-
-    @media (min-width: $lp-min-720)
-      left: (4rem * $scaling-factor)
-      right: (4rem * $scaling-factor)
-      font-size: (2.4rem * $scaling-factor)
-      padding-top: 1px
-      width: calc(100% - #{(8rem * $scaling-factor)})
-
-  .lp-search__close
-    width: (3.8rem * $scaling-factor)
-    height: (3.8rem * $scaling-factor)
-    right: (-.9rem * $scaling-factor)
-
-    @media (min-width: $lp-min-720)
-      right: 0
-
-    &:before
-      font-size: (1.8rem * $scaling-factor)
-
-      @media (min-width: $lp-min-720)
-        font-size: (2rem * $scaling-factor)
-
-  .lp-search-results
-    transform: translateY((-2rem * $scaling-factor))
-
-  .lp-search-results--visible
-    transform: translateY(0)
-
-  .lp-search-results__list
-    margin-bottom: ((4.5rem - .8rem) * $scaling-factor)
-    padding-top: (1rem * $scaling-factor)
-    border-top-width: 1px
-
-  // Pixel value for line-height so that it's more precise
-  .lp-search-item
-    margin-bottom: (1rem * $scaling-factor)
-    line-height: 60px
-
-  .lp-search-item__link
-    padding-left: (11rem * $scaling-factor)
-
-  .lp-search-item__name
-    font-size: (1.8rem * $scaling-factor)
-    border-bottom-width: 1px
-
-    @media (min-width: $lp-min-720)
-      font-size: (2.2rem * $scaling-factor)
-      transform: translateX(0)
-
-  .lp-search-item:hover,
-  .lp-search-item:active,
-  .lp-search-item:focus,
-  .lp-search-item--selected
-    .lp-search-item__name
-      @media (min-width: $lp-min-720)
-        transform: translateX(7px)
-
-  .lp-search-results__more
-    margin-bottom: (4.5rem * $scaling-factor)
-    font-size: (1.2rem * $scaling-factor)
-
-  .lp-search-results__more
-    [class*="icon-"]
-      transform: translateX(6px)
-
-    &:hover [class*="icon-"],
-    &:active [class*="icon-"],
-    &:focus [class*="icon-"]
-      transform: translateX(2px)
 
 
 
@@ -546,51 +429,264 @@ $lp-max-480: #{(479 * .0625)}em // 29.9375em
 
 
 
-  // ---------------------------------------------------------------------------
-  // topic
-  // ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+// mobile-navigation
+// -----------------------------------------------------------------------------
 
-  .topic
-    position: relative
+.mobile-navigation
+  box-sizing: border-box
+  font-family: "Benton Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif
+  padding: (3rem * $scaling-factor) !important
+  width: (25rem * $scaling-factor) !important
 
-  .topic__image
-    background-color: #ccc
-    background-repeat: no-repeat
-    background-size: cover
-    height: (6rem * $scaling-factor)
-    width: (8rem * $scaling-factor)
-    left: 0
-    position: absolute
-    top: 0
+// Pixel values for more precise measurements
+.mobile-navigation__item
+  border-bottom-width: 1px !important
+  font-size: 18px !important
 
-  .topic__image--activity
-    +lp-icon-before("https://assets.staticlp.com/destinations-next/icons/activity--line.svg")
-    background-image: url("https://assets.staticlp.com/destinations-next/images/search-category-image-activities.jpg")
+  .icon
+    width: (1.3rem * $scaling-factor) !important
+    height: (1.3rem * $scaling-factor) !important
+    margin-top: (.6rem * $scaling-factor) !important
 
-  .topic__image--article
-    +lp-icon-before("https://assets.staticlp.com/destinations-next/icons/article--line.svg")
-    background-image: url("https://assets.staticlp.com/destinations-next/images/search-category-image-articles.jpg")
+.mobile-navigation__link
+  line-height: 1.5
+  padding: (1.6rem * $scaling-factor) 0 (1.1rem * $scaling-factor) !important
+  text-decoration: none !important
 
-  .topic__image--collection
-    +lp-icon-before("https://assets.staticlp.com/destinations-next/icons/image--line.svg")
-    background-image: url("https://assets.staticlp.com/destinations-next/images/search-category-image-collection.jpg")
+.mobile-navigation__item--active > .mobile-navigation__link
+  color: #333 !important
 
-  .topic__image--guide
-    +lp-icon-before("https://assets.staticlp.com/destinations-next/icons/book.svg")
-    background-image: url("https://assets.staticlp.com/destinations-next/images/search-category-image-guides.jpg")
 
-  .topic__image--hotel
-    +lp-icon-before("https://assets.staticlp.com/destinations-next/icons/hotel--line.svg")
-    background-image: url("https://assets.staticlp.com/destinations-next/images/search-category-image-hotels.jpg")
 
-  .topic__image--place
-    +lp-icon-before("https://assets.staticlp.com/destinations-next/icons/place.svg")
-    background-image: url("https://assets.staticlp.com/destinations-next/images/search-category-image-place.jpg")
 
-  .topic__image--sight
-    +lp-icon-before("https://assets.staticlp.com/destinations-next/icons/sight--line.svg")
-    background-image: url("https://assets.staticlp.com/destinations-next/images/search-category-image-sights.jpg")
 
-  .topic__image--tour
-    +lp-icon-before("https://assets.staticlp.com/destinations-next/icons/tour--line.svg")
-    background-image: url("https://assets.staticlp.com/destinations-next/images/search-category-image-tours.jpg")
+// -----------------------------------------------------------------------------
+// mobile-sub-navigation
+// -----------------------------------------------------------------------------
+
+.mobile-sub-navigation
+  box-sizing: border-box
+
+.mobile-sub-navigation .sub-navigation-feature
+  padding: 0 0 (2rem * $scaling-factor) !important
+
+// Pixel width because rem calculation is 1 px off
+.mobile-sub-navigation .sub-navigation-feature__image
+  margin-right: (1.4rem * $scaling-factor) !important
+  width: 60px !important
+
+.mobile-sub-navigation .sub-navigation-feature__text
+  padding-top: (.8rem * $scaling-factor) !important
+
+.mobile-sub-navigation .sub-navigation-feature__title
+  font-size: (1.6rem * $scaling-factor) !important
+
+.mobile-sub-navigation .sub-navigation-feature__subtitle
+  font-size: (1.1rem * $scaling-factor) !important
+  margin-top: (.4rem * $scaling-factor) !important
+
+.mobile-sub-navigation .sub-navigation__list
+  padding: 0 !important
+
+.mobile-sub-navigation .sub-navigation__item
+  font-size: (1.6rem * $scaling-factor) !important
+  margin-left: 0 !important
+  margin-right: 0 !important
+
+.mobile-sub-navigation .sub-navigation__link
+  padding: (1rem * $scaling-factor) ($lp-gutter / 2) (.8rem * $scaling-factor) !important
+  text-decoration: none
+
+  &:after
+    height: calc(100% + .2rem) !important
+    left: -$lp-gutter !important
+    right: -$lp-gutter !important
+    top: (-.1rem * $scaling-factor) !important
+    width: calc(100% + #{$lp-gutter} + #{$lp-gutter}) !important
+
+.mobile-sub-navigation .sub-navigation__button
+  font-size: (1.2rem * $scaling-factor) !important
+  padding: (1.8rem * $scaling-factor) (3rem * $scaling-factor) (1.4rem * $scaling-factor) !important
+  border-radius: 0 0 (.2rem * $scaling-factor) (.2rem * $scaling-factor) !important
+  padding-top: (2.3rem * $scaling-factor) !important
+  padding-bottom: (1.9rem * $scaling-factor) !important
+
+
+
+
+
+// ---------------------------------------------------------------------------
+// search
+// ---------------------------------------------------------------------------
+
+.lp-search
+  box-sizing: border-box
+  font-family: "Benton Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif
+
+  @media (min-width: $lp-min-720)
+    box-shadow: (-5rem * $scaling-factor) 0 (15rem * $scaling-factor) rgba(0, 0, 0, .5) !important
+
+  [class^="icon-"],
+  [class*=" icon-"]
+    @extend %lp-icon-font
+
+  .icon-close-small:before
+    content: "\e605"
+
+  .icon-chevron-right:before
+    content: "\e603"
+
+.lp-search--visible
+  @media (min-width: $lp-min-720)
+    box-shadow: (.5rem * $scaling-factor) 0 (23rem * $scaling-factor) rgba(0, 0, 0, .5) !important
+
+.lp-search__container
+  max-width: (129rem * $scaling-factor) !important
+  margin-left: auto !important
+  margin-right: auto !important
+
+  @media (max-width: $lp-max-480)
+    padding-left: ($lp-gutter / 2) !important
+    padding-right: ($lp-gutter / 2) !important
+
+  @media (min-width: $lp-min-480)
+    margin-left: $lp-gutter !important
+    margin-right: $lp-gutter !important
+
+  @media (min-width: $lp-min-1080)
+    margin-left: ($lp-gutter * 2) !important
+    margin-right: ($lp-gutter * 2) !important
+
+  @media (min-width: $lp-min-1410)
+    margin-left: auto !important
+    margin-right: auto !important
+
+.lp-search__inner
+  height: (5rem * $scaling-factor) !important
+  line-height: (3.8rem * $scaling-factor) !important
+
+  @media (min-width: $lp-min-720)
+    height: (13rem * $scaling-factor) !important
+
+  &:after
+    @media (max-width: $lp-max-720)
+      // +lp-fade-edge("right", 29px)
+      background-image: linear-gradient(to left, #fff 0%, rgba(#fff, 0) 100%)
+      bottom: 0
+      content: ""
+      height: 100%
+      position: absolute
+      right: 29px !important
+      top: 0
+      width: 30px !important
+
+.lp-search__label
+  width: (2rem * $scaling-factor) !important
+  height: (2rem * $scaling-factor) !important
+
+  @media (min-width: $lp-min-720)
+    top: (-.4rem * $scaling-factor) !important
+
+  &:before
+    font-size: (2rem * $scaling-factor) !important
+
+.lp-search__input
+  left: (2.5rem * $scaling-factor) !important
+  right: (5.9rem * $scaling-factor) !important
+  width: calc(100% - #{(5rem * $scaling-factor)} - #{(.9rem * $scaling-factor)}) !important
+  height: (3.8rem * $scaling-factor) !important
+  font-size: (1.6rem * $scaling-factor) !important
+
+  @media (max-width: $lp-max-720)
+    padding-top: (.3rem * $scaling-factor) !important
+
+  @media (min-width: $lp-min-720)
+    left: (4rem * $scaling-factor) !important
+    right: (4rem * $scaling-factor) !important
+    font-size: (2.4rem * $scaling-factor) !important
+    padding-top: 1px !important
+    width: calc(100% - #{(8rem * $scaling-factor)}) !important
+
+.lp-search__close
+  width: (3.8rem * $scaling-factor) !important
+  height: (3.8rem * $scaling-factor) !important
+  right: (-.9rem * $scaling-factor) !important
+
+  @media (min-width: $lp-min-720)
+    right: 0 !important
+
+  &:before
+    font-size: (1.8rem * $scaling-factor) !important
+
+    @media (min-width: $lp-min-720)
+      font-size: (2rem * $scaling-factor) !important
+
+.lp-search-results
+  transform: translateY((-2rem * $scaling-factor)) !important
+
+.lp-search-results--visible
+  transform: translateY(0) !important
+
+.lp-search-results__list
+  margin-bottom: ((4.5rem + .6rem) * $scaling-factor) !important
+  padding-top: (1rem * $scaling-factor) !important
+  border-top-width: 1px !important
+
+// Pixel value for line-height so that it's more precise
+.lp-search-item
+  margin-bottom: (1rem * $scaling-factor) !important
+  line-height: 60px !important
+
+.lp-search-item__link
+  padding-left: (11rem * $scaling-factor) !important
+  text-decoration: none !important
+
+.lp-search-item__name
+  font-size: (1.8rem * $scaling-factor) !important
+  border-bottom-width: 1px !important
+
+  @media (min-width: $lp-min-720)
+    font-size: (2.2rem * $scaling-factor) !important
+    transform: translateX(0) !important
+
+.lp-search-item:hover,
+.lp-search-item:active,
+.lp-search-item:focus,
+.lp-search-item--selected
+  .lp-search-item__name
+    @media (min-width: $lp-min-720)
+      transform: translateX(7px) !important
+
+.lp-search-results__more
+  margin-bottom: (4.5rem * $scaling-factor) !important
+  font-size: (1.2rem * $scaling-factor) !important
+
+.lp-search-results__more
+  color: $lp-blue
+  text-decoration: none !important
+
+  &:hover
+  &:active,
+  &:focus
+    color: $lp-blue + 30
+
+  [class*="icon-"]
+    transform: translateX(6px) !important
+
+  &:hover [class*="icon-"],
+  &:active [class*="icon-"],
+  &:focus [class*="icon-"]
+    transform: translateX(2px) !important
+
+
+
+
+
+// ---------------------------------------------------------------------------
+// topic
+// ---------------------------------------------------------------------------
+
+.topic__image
+  height: (6rem * $scaling-factor) !important
+  width: (8rem * $scaling-factor) !important

--- a/app/views/layouts/custom/_head.html.haml
+++ b/app/views/layouts/custom/_head.html.haml
@@ -13,6 +13,9 @@
 = yield :dns_prefetch
 %link{ rel: "dns-prefetch", href: "http://assets.staticlp.com" }
 
+- if show_new_header?
+  %link{rel: "stylesheet", href: "#{asset_path('rizzo-next.css')}"}
+
 %link{ rel: "icon", type: "image/x-icon", href: "https://www.lonelyplanet.com/favicon.ico" }
 
 %meta{ name:"viewport", content: responsive && !@fixed_width_layout ? "width=device-width, initial-scale=1" : "width=1024" }

--- a/app/views/layouts/custom/_post_header.html.haml
+++ b/app/views/layouts/custom/_post_header.html.haml
@@ -3,7 +3,6 @@
     window.lp.isNewNav = "#{show_new_header?}";
 
 - if show_new_header?
-  %link{rel: "stylesheet", href: "#{asset_path('rizzo-next.css')}"}
   .content-wrapper.navigation-wrapper.rizzo-navigation.rizzo-next
     = render :file => 'header'
 - else


### PR DESCRIPTION
Because Rizzo Next uses rems and a base font size 10px and Rizzo uses a base font size of 14px, overrides needed to be added to make the header look the same across all areas of the site.

[View Codepen demo](http://codepen.io/thomasthesecond/pen/977f587e591f7d06d78f40f149bd6ad1)