### PR TITLE
fix jshint error (define _this before using it)

### DIFF
--- a/app/assets/javascripts/lib/components/link_to.js
+++ b/app/assets/javascripts/lib/components/link_to.js
@@ -11,12 +11,13 @@ define([ "jquery" ], function($) {
   "use strict";
 
   var EXCLUDE = [ "A", "BUTTON", "INPUT", "LABEL", "OPTION", "SELECT" ],
+      _this,
       LinkTo = function(context) {
         _this = this;
         context = context || document;
 
         $("[data-link-to]", context).on("click", _this._determineEligibility);
-      }, _this;
+      };
 
   // e: {object} The jQuery click event object.
   LinkTo.prototype._determineEligibility = function(e) {


### PR DESCRIPTION
fix for jshint error:
```app/assets/javascripts/lib/components/link_to.js:19
^ '_this' was used before it was defined.```