### PR TITLE
Setup airbrake only for v4

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,5 +1,15 @@
 if Rails.env.production? && defined?(Airbrake)
-  Airbrake.configure do |config|
-    config.api_key = ENV['AIRBRAKE_API_KEY']
+  airbrake_version = Gem::Version.new(Airbrake::VERSION)
+  new_version = Gem::Version.new('5.0')
+
+  # There is a breaking change in Airbrake API. If an application tries to use
+  # v5 it will crash. This means Rizzo locks out every application from being
+  # updated.
+  #
+  # Skip airbrake config if an application uses v5.
+  if airbrake_version < new_version
+    Airbrake.configure do |config|
+      config.api_key = ENV['AIRBRAKE_API_KEY']
+    end
   end
 end


### PR DESCRIPTION
There is a breaking change in Airbrake API v5. If an application tries to use
v5 it will crash in rizzo initializer. This means Rizzo locks out every application
from being ever updated (just the airbrake).

Skip airbrake config if an application uses v5.