### PR TITLE
Track flights and insurance submits as partner clicks

### DIFF
--- a/app/assets/javascripts/lib/analytics/flights.js
+++ b/app/assets/javascripts/lib/analytics/flights.js
@@ -20,7 +20,7 @@ define([ "jquery" ], function($) {
 
     window.lp.analytics.api.trackEvent({
       category: "Partner",
-      action: "Search",
+      action: "Click",
       label:  "scyscanner.com|Flight|" + this.$locationEnd.val()
     });
 

--- a/app/assets/javascripts/lib/analytics/travel_insurance_omniture.js
+++ b/app/assets/javascripts/lib/analytics/travel_insurance_omniture.js
@@ -31,7 +31,7 @@ require([ "jquery", "lib/analytics/analytics" ], function($, Analytics) {
       if (!$(".js-travel-widget .input-validation-errors").length) {
         window.lp.analytics.api.trackEvent({
           category: "Partner",
-          action:   "Search",
+          action:   "Click",
           label: [
             "Worldnomads",
             "Insurance",


### PR DESCRIPTION
Booking widgets that lead off site (as a result of form submit) should be considered as "Partner Clicks" not "Partner Searches".