### PR TITLE
poi map resizing fix

### DIFF
--- a/app/assets/javascripts/lib/components/poi_map.js
+++ b/app/assets/javascripts/lib/components/poi_map.js
@@ -4,7 +4,7 @@ define([
   "lib/components/map_styles",
   "lib/components/toggle_active",
   "polyfills/function_bind"
-], function($, asEventEmitter, mapStyles, ToggleActive) {
+], function($, asEventEmitter, mapStyles) {
 
   "use strict";
 
@@ -42,11 +42,6 @@ define([
           closeBoxURL: ""
         });
         tooltip.open(_this.map, _this.marker);
-        window.google.maps.event.addListener(tooltip, "domready", function() {
-          new ToggleActive({
-            context: _this.config.container
-          });
-        });
       });
     }
   };


### PR DESCRIPTION
request: https://github.com/lonelyplanet/rizzo/issues/1514
ToggleActive is self-instantiating component, calling its constructor directly will register active class toggling callback second time - that way clicking `.js-toggle-active` will have no effect, since it will fire callbacks twice (setting back original state)