### PR TITLE
Improve adblock check with pixel bait

### DIFF
--- a/app/assets/javascripts/lib/core/advertising.js
+++ b/app/assets/javascripts/lib/core/advertising.js
@@ -1,7 +1,6 @@
-define(function() {
+define([ "jquery" ], function($) {
 
   "use strict";
   // This file is poorly named BUT it has to be named advertising.js otherwise the block_checker script always yields false
-  window.lp.isAdblockActive = false;
-
+  window.lp.isAdblockActive = $(".ads.adpartner").is(":hidden");
 });

--- a/app/assets/stylesheets/core/layouts/modern/_ads.sass
+++ b/app/assets/stylesheets/core/layouts/modern/_ads.sass
@@ -39,6 +39,12 @@
     padding-left: 90px
     padding-right: 90px
 
+.ads.adpartner
+  position: absolute
+  width: 1px
+  height: 1px
+  opacity: 0
+
 .sponsor-logo
   margin-top: 10px
   +respond-to(728 + 180)

--- a/app/views/layouts/partials/snippets/_leaderboard.html.haml
+++ b/app/views/layouts/partials/snippets/_leaderboard.html.haml
@@ -1,6 +1,7 @@
 - unless @hide_leaderboard
   .row.row--sponsored.row--leaderboard.row--leaderboard--header
     .ad-leaderboard
+      .ads.adpartner
       .ad-leaderboard__inner
         = ui_component('ads/leaderboard', properties: { targeting: { position: 'header' } })
         .ad-leaderboard__sponsor


### PR DESCRIPTION
This one adds pixel bait for adblockers. Checking for its visibility can detect some blockers which let `advertising.js` load.

Still, no match for µBlock (:heart:)