### PR TITLE
Datepicker accepts min and max props

### DIFF
--- a/app/views/components/forms/_date_input.html.haml
+++ b/app/views/components/forms/_date_input.html.haml
@@ -1,2 +1,2 @@
-%input.input.input--text.input--datepicker{ type: 'date', id: properties[:id], class: properties[:class], name: properties[:name], placeholder: properties[:placeholder], value: properties[:value] || "", data: properties[:data] ? properties[:data] : {} }
+%input.input.input--text.input--datepicker{ type: 'date', id: properties[:id], class: properties[:class], name: properties[:name], placeholder: properties[:placeholder], value: properties[:value] || '', data: properties[:data] || {}, max: properties[:max], min: properties[:min] }
 = render :partial => 'components/forms/partials/tooltip', :locals => { tooltip: properties[:tooltip] }


### PR DESCRIPTION
Simple update for the datepicker to accept `min` and `max` properties.
```
= ui_component('forms/date_field', properties: { id: "text_id",
    label: "Choose Date",
    max: Date.today,
    min: "2010-01-01",
    name: "text_name",
})
```
