### PR TITLE
Bring back A9 and Criteo tags

### DIFF
--- a/app/views/layouts/partials/inline_js/_a9.html
+++ b/app/views/layouts/partials/inline_js/_a9.html
@@ -1,3 +1,4 @@
+<script type='text/javascript' src='https://c.amazon-adsystem.com/aax2/amzn_ads.js'></script>
 <script type='text/javascript'>
     try {
         amznads.getAds('3231');
@@ -11,3 +12,4 @@
   googletag.cmd = googletag.cmd || [];
   try { amznads.setTargetingForGPTAsync('amznslots'); } catch(e) { /*ignore*/}
 </script>
+

--- a/app/views/layouts/partials/inline_js/_criteo.html
+++ b/app/views/layouts/partials/inline_js/_criteo.html
@@ -1,0 +1,28 @@
+<script type='text/javascript'>
+var crtg_nid = '4008';
+var crtg_cookiename = 'crtg_lonely';
+var crtg_varname = 'crtg_content';
+function crtg_getCookie(c_name){ var i,x,y,ARRCookies=document.cookie.split(";");for(i=0;i<ARRCookies.length;i++){x=ARRCookies[i].substr(0,ARRCookies[i].indexOf("="));y=ARRCookies[i].substr(ARRCookies[i].indexOf("=")+1);x=x.replace(/^\s+|\s+$/g,"");if(x==c_name){return unescape(y);} }return'';}
+var crtg_content = crtg_getCookie(crtg_cookiename);
+var crtg_rnd=Math.floor(Math.random()*99999999999);
+(function(){
+var crtg_url=location.protocol+'//rtax.criteo.com/delivery/rta/rta.js?netId='+escape(crtg_nid);
+crtg_url +='&cookieName='+escape(crtg_cookiename);
+crtg_url +='&rnd='+crtg_rnd;
+crtg_url +='&varName=' + escape(crtg_varname);
+var crtg_script=document.createElement('script');crtg_script.type='text/javascript';crtg_script.src=crtg_url;crtg_script.async=true;
+if(document.getElementsByTagName("head").length>0)document.getElementsByTagName("head")[0].appendChild(crtg_script);
+else if(document.getElementsByTagName("body").length>0)document.getElementsByTagName("body")[0].appendChild(crtg_script);
+})();
+</script>
+
+<script type="text/javascript">
+    var googletag = googletag || {};
+    googletag.cmd = googletag.cmd || [];
+    var crtg_split = crtg_content.split(';');
+    for (var i = 1; i < crtg_split.length; i++) {
+        if (crtg_split[i - 1].indexOf('=') == -1) continue;
+        var sp = crtg_split[i - 1].split('=');
+        googletag.cmd.push((function(key, value) {return function() {googletag.pubads().setTargeting(key, value); } })(sp[0], sp[1]) );
+    }
+</script>

--- a/app/views/layouts/partials/snippets/_head_js.haml
+++ b/app/views/layouts/partials/snippets/_head_js.haml
@@ -94,6 +94,7 @@
 = render 'layouts/partials/inline_js/load_css'
 = render 'layouts/partials/inline_js/krux'
 = render 'layouts/partials/inline_js/a9'
+= render 'layouts/partials/inline_js/criteo'
 
 :javascript
   // Google analytics


### PR DESCRIPTION
Due to problems with their implementation in Tealium (they introduced dependency on DFP; not added to Tealium yet). 