### PR TITLE
fix mixed content

### DIFF
--- a/app/assets/javascripts/lib/widgets/flights_autocomplete.js
+++ b/app/assets/javascripts/lib/widgets/flights_autocomplete.js
@@ -34,7 +34,7 @@ define([
   FlightsWidgetAutocomplete.prototype.getCountryCode = function() {
     return $.ajax({
       type: "GET",
-      url: "http://www.lonelyplanet.com",
+      url: "https://www.lonelyplanet.com",
       success: function(data, textStatus, request) {
           this.countryCode = request.getResponseHeader("X-GeoIP-CountryCode") || "US";
         }.bind(this)


### PR DESCRIPTION
request: https://trello.com/c/EYctfZHq/188-flight-booking-tool-not-auto-filling-city-names
This widget used on https pages throws Mixed Content errors when requesting insecure (http) endpoint.