### PR TITLE
use new proxy endpoint for skyscanner autosuggest

### DIFF
--- a/app/assets/javascripts/lib/widgets/flights_autocomplete.js
+++ b/app/assets/javascripts/lib/widgets/flights_autocomplete.js
@@ -29,8 +29,6 @@ define([
     this.setupAutocomplete(this.$toCity);
   };
 
-  FlightsWidgetAutocomplete.prototype.API_KEY = "lp994363056324023341132625613270";
-
   FlightsWidgetAutocomplete.prototype.getCountryCode = function() {
     return $.ajax({
       type: "GET",
@@ -75,12 +73,12 @@ define([
 
   FlightsWidgetAutocomplete.prototype._fetchCountries = function(searchTerm, callback) {
     $.ajax({
-      type: "GET",
-      dataType: "JSONP",
+      type: "get",
+      dataType: "json",
       url: this._buildUrl(searchTerm)
     }).done(function(data) {
       var city, places;
-      places = data.Places.filter(function(el) {
+      places = data.filter(function(el) {
         return el.CityId !== "-sky";
       });
       city = "";
@@ -93,7 +91,7 @@ define([
   };
 
   FlightsWidgetAutocomplete.prototype._buildUrl = function(searchTerm) {
-    return "http://partners.api.skyscanner.net/apiservices/xd/autosuggest/v1.0/" + ("" + this.countryCode + "/" + this.userCurrency + "/en-GB?query=" + searchTerm + "&apikey=" + this.API_KEY);
+    return "https://www.lonelyplanet.com/skyscanner/location-autosuggest?" + "user_currency=" + this.userCurrency + "&user_locale=en-GB" + "&user_country_code=" + this.countryCode + "&location_name=" + searchTerm;
   };
 
   FlightsWidgetAutocomplete.prototype._onSelectCity = function($item) {


### PR DESCRIPTION
request: https://trello.com/c/EYctfZHq/188-flight-booking-tool-not-auto-filling-city-names
Location autocomplete never worked (or stopped working some time ago) over https, I guess because skyscanner stopped supporting jsonp or new browsers introduced some more strict security policies - I don't really know.
Anyways, I think jsonp is not a good idea (executing third-party script on our side), besides that we were exposing our skyscanner private api key - definitely not a good idea. I decided to implement proxy endpoint in need-to-know: https://github.com/lonelyplanet/need-to-know/pull/391
dispatch p/r: https://github.com/lonelyplanet/dispatch/pull/663