### PR TITLE
Link legacy data layer objects to lp.dataLayer global

### DIFF
--- a/app/views/layouts/partials/snippets/_head_js.haml
+++ b/app/views/layouts/partials/snippets/_head_js.haml
@@ -17,8 +17,9 @@
   window.lp = window.lp || {};
 
   // Allow legacy apps to add their own properties
-  window.lp.tracking = window.lp.tracking || {};
-  window.lp.supports = window.lp.supports || {};
+  window.lp.tracking  = window.lp.tracking  || {};
+  window.lp.supports  = window.lp.supports  || {};
+  window.lp.dataLayer = window.lp.dataLayer || {};
 
   // Setting up Adblock checker
   window.lp.isAdblockActive = true;
@@ -90,6 +91,11 @@
 :javascript
   // Alias for utag_data required by Tealium
   window.utag_data = window.lp.analytics.utag_data;
+
+  // Universal Data Object to use with GTM; for now contains
+  // data from Tealium and Omniture (if present)
+  window.lp.dataLayer = window.lp.analytics.utag_data;
+  window.lp.dataLayer.omniture = window.lp.tracking;
 
 = render 'layouts/partials/inline_js/gtm'
 = render 'layouts/partials/inline_js/load_css'


### PR DESCRIPTION
This links legacy data objects used by Tealium and Omniture to `lp.dataLayer` global. 

`lp.dataLayer` will be prime data source for Google Tag Manager. 