### PR TITLE
Change default context for SelectGroupManager

### DIFF
--- a/app/assets/javascripts/lib/components/select_group_manager.js
+++ b/app/assets/javascripts/lib/components/select_group_manager.js
@@ -3,7 +3,7 @@ define([ "jquery" ], function($) {
   "use strict";
 
   var defaults = {
-    listener: ".js-wrapper"
+    listener: "body"
   };
 
   function SelectGroupManager(context) {


### PR DESCRIPTION
Because we sometimes want to use select in Lightbox and it's not under `.js-wrapper`.