### PR TITLE
Give lightbox "above-ad" z-layer

### DIFF
--- a/app/assets/stylesheets/components/_lightbox.sass
+++ b/app/assets/stylesheets/components/_lightbox.sass
@@ -1,7 +1,7 @@
 $lightbox-width: 800px !default
 
 .lightbox
-  +z-layer(modal)
+  +z-layer(above-ad)
   +alpha-background($darkgray, 0.75)
   width: 100%
   height: 100%


### PR DESCRIPTION
This will put the lightbox component above all ads that may have a
high z-index as well as above the secondary-nav component, which is
the component that the "above-ad" z-layer was originally created for
in #1593

Closes #1595