### PR TITLE
fix mixed content for app-core-legacy.css in legacy apps

### DIFF
--- a/app/lib/layout_support.rb
+++ b/app/lib/layout_support.rb
@@ -67,6 +67,7 @@ module LayoutSupport
         ads_header:     false
       },
       legacy: {
+        secure:         true,
         responsive:     false,
         legacy_lp:      true
       },

--- a/features/global_resource.feature
+++ b/features/global_resource.feature
@@ -14,7 +14,7 @@ Feature: Global Resources
   Scenario: it serves the global-head
     Given I go to "/global-head"
     Then the base global-head content should be displayed
-    And the non-secure global-head content should be displayed
+    And the secure global-head content should be displayed
 
   Scenario: it serves the responsive global-head
     Given I go to "/global-head/responsive"


### PR DESCRIPTION
Css is broken on shop over https: mixed content for app-core-legacy.css.
The same for lponline and contact-us - all those apps fetch header from http://rizzo.lonelyplanet.com/global-head. 