### PR TITLE
Prevent left nav's active item border from adding padding

### DIFF
--- a/app/assets/stylesheets/components/_left_nav.sass
+++ b/app/assets/stylesheets/components/_left_nav.sass
@@ -68,6 +68,7 @@
   &.is-active
     &, &:hover
       @extend %active-background
+      padding-left: 13px
 
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Before:

<img width="206" alt="screenshot 2017-08-10 10 54 17" src="https://user-images.githubusercontent.com/1451471/29162621-485eebec-7dba-11e7-9a69-3b419f25291b.png">

After: 

<img width="204" alt="screenshot 2017-08-10 10 52 48" src="https://user-images.githubusercontent.com/1451471/29162620-483fd7e8-7dba-11e7-9330-98ddd0de8e83.png">
