### PR TITLE
Make LinkTo use single (context) listener

### DIFF
--- a/app/assets/javascripts/lib/components/link_to.js
+++ b/app/assets/javascripts/lib/components/link_to.js
@@ -13,21 +13,30 @@ define([ "jquery" ], function($) {
   var EXCLUDE = [ "A", "BUTTON", "INPUT", "LABEL", "OPTION", "SELECT" ];
 
   function LinkTo(context) {
-    context = context || document;
+    this.$context = $(context || document);
+    this._determineEligibility = this._determineEligibility.bind(this);
 
-    $("[data-link-to]", context).on("click", this._determineEligibility.bind(this));
+    this._init();
   }
 
-  // e: {object} The jQuery click event object.
-  LinkTo.prototype._determineEligibility = function(e) {
-    var $target = $(e.target),
-        $card = $target.data("data-link-to") ? e.target : $target.closest("[data-link-to]"),
-        inExclude = $.inArray(e.target.nodeName.toUpperCase(), EXCLUDE) !== -1,
-        excluded = inExclude || $target.hasClass("js-prevent-link-to");
+  LinkTo.prototype._init = function() {
+    this._listen();
+  };
+
+  LinkTo.prototype._listen = function() {
+    this.$context.on("click", "[data-link-to]", this._determineEligibility);
+  };
+
+  // event: {object} The jQuery click event object.
+  LinkTo.prototype._determineEligibility = function(event) {
+    var $linkToEl = $(event.currentTarget),
+        $clickedEl = $(event.target),
+        inExclude = EXCLUDE.indexOf($clickedEl[0].nodeName.toUpperCase()) > -1,
+        excluded = inExclude || $clickedEl.hasClass("js-prevent-link-to");
 
     // Make sure we don't hijack click events from certain elements.
     if (!excluded) {
-      this._redirect($card.data("linkTo"));
+      this._redirect($linkToEl.data("linkTo"));
     }
   };
 

--- a/spec/javascripts/fixtures/link_to.html
+++ b/spec/javascripts/fixtures/link_to.html
@@ -1,11 +1,13 @@
-<div data-link-to="/foo">
-  <p></p>
-  <a href="bar"></a>
-  <button name="baz"></button>
-  <input type="text" name="qoo" value="">
-  <label for="qoo"></label>
-  <select name="qux">
-    <option value="qux"></option>
-  </select>
-  <a href="bar" class="js-prevent-link-to"></a>
+<div id="listener">
+  <div data-link-to="/foo">
+    <p></p>
+    <a href="bar"></a>
+    <button name="baz"></button>
+    <input type="text" name="qoo" value="">
+    <label for="qoo"></label>
+    <select name="qux">
+      <option value="qux"></option>
+    </select>
+    <a href="bar" class="js-prevent-link-to"></a>
+  </div>
 </div>

--- a/spec/javascripts/lib/components/link_to_spec.js
+++ b/spec/javascripts/lib/components/link_to_spec.js
@@ -1,15 +1,18 @@
-define([ "jquery", "public/assets/javascripts/lib/components/link_to" ], function($, LinkTo) {
+define([
+  "jquery",
+  "public/assets/javascripts/lib/components/link_to"
+], function($, LinkTo) {
 
   "use strict";
 
   describe("linkTo", function() {
 
-    var $container, linkTo;
+    var $container, linkTo, redirectSpy;
 
     beforeEach(function() {
       loadFixtures("link_to.html");
-      linkTo = new LinkTo();
-      spyOn(linkTo, "_redirect");
+      linkTo = new LinkTo("#listener");
+      redirectSpy = spyOn(LinkTo.prototype,  "_redirect");
 
       $container = $("[data-link-to]");
     });
@@ -18,47 +21,47 @@ define([ "jquery", "public/assets/javascripts/lib/components/link_to" ], functio
 
       it("happens when the element itself is clicked on", function() {
         $container.trigger("click");
-        expect(linkTo._redirect).toHaveBeenCalledWith("/foo");
+        expect(redirectSpy).toHaveBeenCalledWith("/foo");
       });
 
       it("happens when a non-blacklisted element is clicked on", function() {
         $container.find("p").trigger("click");
-        expect(linkTo._redirect).toHaveBeenCalledWith("/foo");
+        expect(redirectSpy).toHaveBeenCalledWith("/foo");
       });
 
       it("doesn't happen when an anchor element is clicked on", function() {
         $container.find("a").trigger("click");
-        expect(linkTo._redirect).not.toHaveBeenCalled();
+        expect(redirectSpy).not.toHaveBeenCalled();
       });
 
       it("doesn't happen when a button element is clicked on", function() {
         $container.find("button").trigger("click");
-        expect(linkTo._redirect).not.toHaveBeenCalled();
+        expect(redirectSpy).not.toHaveBeenCalled();
       });
 
       it("doesn't happen when an input element is clicked on", function() {
         $container.find("input").trigger("click");
-        expect(linkTo._redirect).not.toHaveBeenCalled();
+        expect(redirectSpy).not.toHaveBeenCalled();
       });
 
       it("doesn't happen when a label element is clicked on", function() {
         $container.find("label").trigger("click");
-        expect(linkTo._redirect).not.toHaveBeenCalled();
+        expect(redirectSpy).not.toHaveBeenCalled();
       });
 
       it("doesn't happen when an option element is clicked on", function() {
         $container.find("option").trigger("click");
-        expect(linkTo._redirect).not.toHaveBeenCalled();
+        expect(redirectSpy).not.toHaveBeenCalled();
       });
 
       it("doesn't happen when a select element is clicked on", function() {
         $container.find("select").trigger("click");
-        expect(linkTo._redirect).not.toHaveBeenCalled();
+        expect(redirectSpy).not.toHaveBeenCalled();
       });
 
       it("doesn't happen when element with 'js-prevent-link-to' class is clicked on", function() {
         $container.find(".js-prevent-link-to").trigger("click");
-        expect(linkTo._redirect).not.toHaveBeenCalled();
+        expect(redirectSpy).not.toHaveBeenCalled();
       });
 
     });


### PR DESCRIPTION
It has other benefits, but I just needed it to support dynamically appended `data-link-to`s.