### PR TITLE
Update sprockets due to security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
       websocket (~> 1.0.4)
     sexp_processor (4.10.1)
     slop (3.6.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (2.3.3)
@@ -256,4 +256,4 @@ DEPENDENCIES
   unicorn
 
 BUNDLED WITH
-   1.14.6
+   1.16.1


### PR DESCRIPTION
Announcement: [CVE-2018-3760](https://groups.google.com/forum/#!topic/ruby-security-ann/2S9Pwz2i16k)