### PR TITLE
Set default dates from the 'value' html attr

### DIFF
--- a/app/assets/javascripts/lib/components/availability_search.js
+++ b/app/assets/javascripts/lib/components/availability_search.js
@@ -92,7 +92,7 @@ define([
   };
 
   AvailabilitySearch.prototype._getSearchData = function() {
-    if (!this.$startDate.val()) {
+    if (!this.$startDate.attr("value")) {
       this._setDefaultDates();
     }
 

--- a/app/assets/javascripts/lib/components/datepicker.js
+++ b/app/assets/javascripts/lib/components/datepicker.js
@@ -32,7 +32,9 @@ define([ "jquery", "picker", "pickerDate", "pickerLegacy" ], function($) {
     var config = this.config,
         options = this._getOptions(),
         $inDate = this.$target.find(config.startSelector),
-        $outDate = this.$target.find(config.endSelector);
+        $outDate = this.$target.find(config.endSelector),
+        defaultInDate = $inDate.attr("value"),
+        defaultOutDate = $outDate.attr("value");
 
     this.$inLabel = $(config.startLabelSelector);
     this.$outLabel = $(config.endLabelSelector);
@@ -44,6 +46,13 @@ define([ "jquery", "picker", "pickerDate", "pickerLegacy" ], function($) {
 
     this.inPicker = $inDate.data("pickadate");
     this.outPicker = $outDate.data("pickadate");
+
+    if (defaultInDate) {
+      this.inPicker.set("select", defaultInDate, { format: config.dateFormat });
+    }
+    if (defaultOutDate) {
+      this.outPicker.set("select", defaultOutDate, { format: config.dateFormat });
+    }
 
     this.listen();
   };

--- a/spec/javascripts/fixtures/availability.html
+++ b/spec/javascripts/fixtures/availability.html
@@ -25,8 +25,8 @@
 
   <div class="js-availability-card-with-values">
     <form class="js-availability">
-      <input type="text" id="js-av-start" value="06 Jun 2013" name="search[from]" />
-      <input type="text" id="js-av-end" value="07 Jun 2013" name="search[to]" />
+      <input type="text" id="js-av-start" value="6 Jun 2013" name="search[from]" />
+      <input type="text" id="js-av-end" value="7 Jun 2013" name="search[to]" />
       <select id="js-guests" name="search[guests]">
         <option value="1" selected>1 Adult</option>
       </select>

--- a/spec/javascripts/lib/components/availability_search_spec.js
+++ b/spec/javascripts/lib/components/availability_search_spec.js
@@ -3,6 +3,15 @@ define([ "public/assets/javascripts/lib/components/availability_search.js" ], fu
   describe("Availability", function() {
     var LISTENER = "#js-card-holder";
 
+    beforeEach(function() {
+      jasmine.clock().install();
+      jasmine.clock().mockDate(new Date("1 Jun 2013"));
+    });
+
+    afterEach(function() {
+      jasmine.clock().uninstall();
+    });
+
     describe("Initialisation", function() {
       beforeEach(function() {
         loadFixtures("availability.html");
@@ -33,21 +42,18 @@ define([ "public/assets/javascripts/lib/components/availability_search.js" ], fu
 
         it("serializes the search data", function() {
           var expectedResult, values;
-          values = av._getSearchData(),
 
-          currentDate = new Date(),
-          currentYear = currentDate.getFullYear(),
-          currentMonth = currentDate.toLocaleDateString("en-US", { month: "short" }),
-          currentDay = currentDate.getDate();
+          values = av._getSearchData();
 
           expectedResult = {
             search: {
-              from: `${currentDay} ${currentMonth} ${currentYear}`,
-              to: `${currentDay + 1} ${currentMonth} ${currentYear}`,
+              from: "6 Jun 2013",
+              to: "7 Jun 2013",
               guests: "1",
               currency: "USD"
             }
           };
+
           expect(values).toEqual(expectedResult);
         });
       });

--- a/spec/javascripts/lib/components/availability_search_spec.js
+++ b/spec/javascripts/lib/components/availability_search_spec.js
@@ -33,11 +33,17 @@ define([ "public/assets/javascripts/lib/components/availability_search.js" ], fu
 
         it("serializes the search data", function() {
           var expectedResult, values;
-          values = av._getSearchData();
+          values = av._getSearchData(),
+
+          currentDate = new Date(),
+          currentYear = currentDate.getFullYear(),
+          currentMonth = currentDate.toLocaleDateString("en-US", { month: "short" }),
+          currentDay = currentDate.getDate();
+
           expectedResult = {
             search: {
-              from: "06 Jun 2013",
-              to: "07 Jun 2013",
+              from: `${currentDay} ${currentMonth} ${currentYear}`,
+              to: `${currentDay + 1} ${currentMonth} ${currentYear}`,
               guests: "1",
               currency: "USD"
             }


### PR DESCRIPTION
Solves the bug that dates are not picked up from the 'value' and prepopulated at page reload.
Example: https://www.lonelyplanet.com/thorntree/travel_companions