### PR TITLE
Add global header ssi code to rizzo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Rizzo is the UI layer for lonelyplanet.com. Rizzo also serves LP's header and fo
 
 The main goal of Rizzo is to enable sharing of templates and assets across all LP applications. This helps us to reduce complexity and increase reusability. There is a write-up of the thought process behind Rizzo on the [engineering blog](http://engineering.lonelyplanet.com/2014/05/18/a-maintainable-styleguide.html).
 
-
 ## Install & Get Dependencies
 
 ```bash
@@ -26,34 +25,64 @@ $ touch app/assets/stylesheets/fonts/_font.sass
 $ touch app/assets/stylesheets/fonts/_font_woff2.sass
 ```
 
+## Local Development
+
+You can test your rizzo changes locally by using a repo that requires rizzo. The following steps use [gonzo](https://github.com/lonelyplanet/gonzo) as an example.
+
+1. If you don't have gonzo working locally yet, follow the setup instructions for the repo.
+
+2. In gonzo's `Gemfile`, replace the existing rizzo path with the path to your local rizzo directory:
+
+   ```
+   gem 'rizzo', path: '/Users/local-path/rizzo', submodules: true
+   ```
+
+3. Reinstall the gems:
+
+   ```
+   bundle install
+   ```
+
+4. Run the repo's rails server:
+
+   ```
+   bundle exec rails s
+   ```
+
+5. Open http://localhost:3000/newsletter
+
 ## Documentation
 
 Full documentation about Rizzo and development guidelines is available at [https://rizzo.lonelyplanet.com/documentation/general/development-principles](https://rizzo.lonelyplanet.com/documentation/general/development-principles).
 
-## Jasmine Tests
+## Running Tests
+
+### Javascript tests & linting
+
 There is a suite of JavaScript tests in `spec/javascripts`. These tests are currently using Jasmine v1.x from `grunt-contrib-jasmine` v0.5.x.
 
-In order to run the tests you'll need a few things installed with node.js.
+1. Install the node packages needed for running the tests:
+
+   ```shell
+   npm install -g grunt-cli  # Install grunt globally
+   npm install # Install packages from package.json
+   ```
+
+2. Run the JS tests and linter:
+
+   ```shell
+   grunt ci
+   grunt jshint
+   grunt jscs
+   ```
+
+   The `grunt ci` test output should look like:
+
+   ![](http://d.pr/i/jSY4+)
+
+### Ruby tests
 
 ```shell
-npm install -g grunt-cli  # Install grunt globally
-npm install # Install packages from package.json
-```
-
-You can now run the following to run the tests with grunt...
-
-```shell
-grunt ci
-``` 
-
-It should look like...
-![](http://d.pr/i/jSY4+)
-
-##Run tests
-```shell
-grunt ci
-grunt jshint
-grunt jscs
 bundle exec rspec
 bundle exec cucumber
-
+```

--- a/app/views/layouts/custom/_header.html.haml
+++ b/app/views/layouts/custom/_header.html.haml
@@ -1,2 +1,2 @@
 = render 'layouts/custom/pre_header', third_party: third_party
-= render 'layouts/custom/post_header', legacy_header: legacy_header, search: search, user_nav: user_nav, include_js: include_js, nav_primary: nav_primary, responsive: responsive, ads_header: ads_header
+= render 'layouts/custom/post_header', legacy_header: legacy_header, search: search, user_nav: user_nav, include_js: include_js, nav_primary: nav_primary, responsive: responsive, ads_header: ads_header, global_header: (defined?(global_header) ? global_header : false), global_header_theme: (defined?(global_header_theme) ? global_header_theme : "blue")

--- a/app/views/layouts/custom/_post_header.html.haml
+++ b/app/views/layouts/custom/_post_header.html.haml
@@ -1,7 +1,11 @@
 - if legacy_header
   .content-wrapper.navigation-wrapper
     = render 'layouts/partials/snippets/primary_navigation_bar', search: search, user_nav: user_nav, include_js: include_js, nav_primary: nav_primary, responsive: responsive
-- unless legacy_header
+- elsif global_header
+  .global-header-wrapper
+    - html = "<!--#include virtual='/global-ui/header/#{global_header_theme}' -->"
+    = html.html_safe
+- else
   .content-wrapper.navigation-wrapper.rizzo-navigation.rizzo-next
     = render :file => 'header'
 

--- a/app/views/layouts/custom/preview.html.haml
+++ b/app/views/layouts/custom/preview.html.haml
@@ -11,7 +11,7 @@
   = render 'layouts/custom/pre_header', third_party: third_party
 
   .wrapper.js-wrapper
-    = render 'layouts/custom/post_header', legacy_header: legacy_header, search: search, user_nav: user_nav, include_js: include_js, nav_primary: nav_primary, responsive: responsive, ads_header: ads_header
+    = render 'layouts/custom/post_header', legacy_header: legacy_header, search: search, user_nav: user_nav, include_js: include_js, nav_primary: nav_primary, responsive: responsive, ads_header: ads_header, global_header: (defined?(global_header) ? global_header : false), global_header_theme: (defined?(global_header_theme) ? global_header_theme : "blue")
 
     .row.row--content{ id: "js-row--content" }
       .row.row--secondary#js-secondary-nav

--- a/app/views/layouts/responsive.html.haml
+++ b/app/views/layouts/responsive.html.haml
@@ -11,7 +11,7 @@
   = render 'layouts/custom/pre_header', third_party: false
   .wrapper.js-wrapper
     - unless @no_nav
-      = render 'layouts/custom/post_header', legacy_header: false, search: true, user_nav: true, include_js: true, nav_primary: true, responsive: true, ads_header: true
+      = render 'layouts/custom/post_header', legacy_header: false, search: true, user_nav: true, include_js: true, nav_primary: true, responsive: true, ads_header: true, global_header: (defined?(global_header) ? global_header : false), global_header_theme: (defined?(global_header_theme) ? global_header_theme : "blue")
 
     .row.row--content{id: @no_wallpaper ? "" : "js-row--content"}
       - if (yield :secondary).present?


### PR DESCRIPTION
This code adds the new global header to rizzo. To use it, apps will have to pass in `global_header: true`. The global header theme can also be passed in as `global_header_theme: "white"`.