### PR TITLE
[ADS-122] feat: create block for lp_analytics, omit gtm.js snippet if content p…

### DIFF
--- a/app/views/layouts/partials/snippets/_head_js.haml
+++ b/app/views/layouts/partials/snippets/_head_js.haml
@@ -81,9 +81,12 @@
     time: function(x){!!window.performance && !!window.performance.now && this.buffer.push({e: x, t: this.now()})}
   };
 
+= yield :lp_analytics
 = yield :head_js
 
-= render 'layouts/partials/inline_js/gtm'
+- unless (yield :lp_analytics).present?
+  = render 'layouts/partials/inline_js/gtm'
+
 = render 'layouts/partials/inline_js/load_css'
 = render 'layouts/partials/inline_js/recaptcha'
 


### PR DESCRIPTION
…rovided

As I comb through codebases I've been swapping out `gtm.js` snippet code for the one produced by `lp-analytics`'s `Tracker` class.

In practice they wind up being the same thing, but additional trackers could be added to `lp-analytics`. Figure I might as well be thorough in moving to that implementation.

Anyway, Rizzo has been giving me problems in that it has the `gtm` snippet baked in, meaning that if I added `lp-analytics`'s `initialize-tracking-containers` script on _top_ of that, it could wind up pretty expressly _not good_.

So this adds a block into which we can put whatever `lp_analytics` scripts we might need to add. It's up in the head tag, where it should be. And if anything is provided there, we omit the `gtm.js` snippet provided by Rizzo (so we'll need to provide it to the block, but this is the pattern everywhere else, so I think it's fine).