### PR TITLE
[ADS-141] include user-status ssi tag

### DIFF
--- a/app/views/layouts/custom/_head.html.haml
+++ b/app/views/layouts/custom/_head.html.haml
@@ -24,6 +24,8 @@
 
 = csrf_meta_tags
 
+<!--#include virtual="/global-ui/user-status" -->
+
 - if include_js
   = render 'layouts/partials/snippets/head_js', third_party: third_party
 


### PR DESCRIPTION
Puts `<!--#include virtual="/global-ui/user-status" -->` (that's the extent of the PR) into `_head.html.haml`.

This will cover the major `rizzo` layouts (`minimal`, `responsive`, and `styleguide`).

End goal is to have this tag included such that user authentication details are available for tracking purposes.

I'm going to start by utilizing this data in `gonzo` and move forward from there; I think we're going to focus on these legacy apps in the next sprint. This will facilitate that effort.