### PR TITLE
[ADS-149] feat: create query param for omitting gtm.js snippet from global_head

### DIFF
--- a/app/controllers/layout_controller.rb
+++ b/app/controllers/layout_controller.rb
@@ -4,7 +4,7 @@ class LayoutController < ActionController::Base
   include LayoutSupport
 
   def snippet
-    render "layouts/custom/_#{params[:snippet]}", locals: get_layout_config(params[:route])
+    render "layouts/custom/_#{params[:snippet]}", locals: get_layout_config(params[:route], request.query_parameters)
   end
 
   def preview

--- a/app/lib/layout_support.rb
+++ b/app/lib/layout_support.rb
@@ -7,6 +7,7 @@ module LayoutSupport
       ads_footer:     false,
       include_js:     true,
       languages:      true,
+      omit_gtm_snippet: false,
       nav_primary:    true,
       search:         true,
       nav_sitemap:    true,
@@ -78,12 +79,23 @@ module LayoutSupport
     }
   end
 
-  def get_layout_config(layout_type)
+  def get_options_from_query_params(query_parameters)
+    # only include key/value pair if key is present in query params
+    # so as to not overwrite defaults/options when no query param was provided in the first place.
+    # When present, these will overwrite both layout defaults & layout options.
+    # Be sure to properly sanitize.
+    {
+      :omit_gtm_snippet => query_parameters.fetch("omit_gtm_snippet", "false").to_s == "true"
+    }
+    .select{ |key| query_parameters.key?(key.to_s) }
+  end
+
+  def get_layout_config(layout_type, query_parameters = {})
+    layout_config = layout_defaults.clone
     if layout_options[:"#{layout_type}"]
-      layout_defaults.merge(layout_options[:"#{layout_type}"])
-    else
-      layout_defaults
+      layout_config.merge!(layout_options[:"#{layout_type}"])
     end
+    layout_config.merge(get_options_from_query_params(query_parameters))
   end
 
   def get_layout(route)

--- a/app/views/layouts/custom/_head.html.haml
+++ b/app/views/layouts/custom/_head.html.haml
@@ -25,7 +25,7 @@
 = csrf_meta_tags
 
 - if include_js
-  = render 'layouts/partials/snippets/head_js', third_party: third_party
+  = render 'layouts/partials/snippets/head_js', third_party: third_party, omit_gtm_snippet: omit_gtm_snippet
 
 - if legacy_lp
   = smart_stylesheet('core_legacy')

--- a/app/views/layouts/custom/preview.html.haml
+++ b/app/views/layouts/custom/preview.html.haml
@@ -1,6 +1,6 @@
 = render 'layouts/partials/snippets/doctype_declaration'
 %head
-  = render "layouts/custom/head", include_js: include_js, responsive: responsive, third_party: third_party, app_core: app_core, legacy_lp: legacy_lp, default_title: default_title
+  = render "layouts/custom/head", include_js: include_js, responsive: responsive, third_party: third_party, app_core: app_core, legacy_lp: legacy_lp, default_title: default_title, omit_gtm_snippet: omit_gtm_snippet
 
   - if include_js
     %script

--- a/app/views/layouts/minimal.html.haml
+++ b/app/views/layouts/minimal.html.haml
@@ -1,7 +1,7 @@
 = render 'layouts/partials/snippets/doctype_declaration'
 
 %head
-  = render 'layouts/custom/head', responsive: true, include_js: true, third_party: false, legacy_lp: false, app_core: false, default_title: true
+  = render 'layouts/custom/head', responsive: true, include_js: true, third_party: false, legacy_lp: false, app_core: false, default_title: true, omit_gtm_snippet: false
 
 %body.responsive.minimal
   .wrapper.js-wrapper

--- a/app/views/layouts/partials/snippets/_head_js.haml
+++ b/app/views/layouts/partials/snippets/_head_js.haml
@@ -84,7 +84,7 @@
 = yield :lp_analytics
 = yield :head_js
 
-- unless (yield :lp_analytics).present?
+- unless (yield :lp_analytics).present? or omit_gtm_snippet
   = render 'layouts/partials/inline_js/gtm'
 
 = render 'layouts/partials/inline_js/load_css'

--- a/app/views/layouts/responsive.html.haml
+++ b/app/views/layouts/responsive.html.haml
@@ -1,7 +1,7 @@
 = render 'layouts/partials/snippets/doctype_declaration'
 
 %head
-  = render 'layouts/custom/head', include_js: true, responsive: true, third_party: false, legacy_lp: false, app_core: false, default_title: true
+  = render 'layouts/custom/head', include_js: true, responsive: true, third_party: false, legacy_lp: false, app_core: false, default_title: true, omit_gtm_snippet: false
 
 %body.responsive
   = render 'layouts/partials/snippets/gtm'

--- a/app/views/layouts/styleguide.html.haml
+++ b/app/views/layouts/styleguide.html.haml
@@ -1,7 +1,7 @@
 = render 'layouts/partials/snippets/doctype_declaration'
 
 %head
-  = render 'layouts/custom/head', responsive: false, third_party: false, include_js: true, legacy_lp: false, app_core: false, default_title: true
+  = render 'layouts/custom/head', responsive: false, third_party: false, include_js: true, legacy_lp: false, app_core: false, default_title: true, omit_gtm_snippet: false
   = stylesheet_link_tag 'styleguide', :media => "all"
 
 %body


### PR DESCRIPTION
I'd rather add this in consistently in each repo, so need a way to make `rizzo` omit it from the `global_head` route.